### PR TITLE
Add TFCE cluster inference

### DIFF
--- a/config/snpm_bch_pp.m
+++ b/config/snpm_bch_pp.m
@@ -164,7 +164,19 @@ ClusMass.tag = 'ClusMass';
 ClusMass.val = {PFilt PrimThresh theta};
 ClusMass.help = {'Specify cluster-mass inference'};
 
+FWEthCSS        = cfg_entry;
+FWEthCSS.tag    = 'FWEthCSS';
+FWEthCSS.name   = 'Significance Level (FWE Corrected)';
+FWEthCSS.strtype= 'e';
+FWEthCSS.num    = [1 1];
+FWEthCSS.def    = @(val)snpm_get_defaults('FWElevel', val{:});
+FWEthCSS.help   = {'Enter a FWE significance level threshold.  This threshold is applied to a cluster-like support score image.'};
 
+ClusTFCE = cfg_branch;
+ClusTFCE.name = 'Threshold-free cluster inference';
+ClusTFCE.tag = 'ClusTFCE';
+ClusTFCE.val = {FWEthCSS};
+ClusTFCE.help = {'Specify threshold-free inference'};
 
 Clus = cfg_choice;
 Clus.name = 'Cluster-Level Inference';
@@ -176,7 +188,7 @@ Clus.help = {'Select cluster-level statistic'};
 ThrType        = cfg_choice;
 ThrType.name   = 'Type of Thresholding';
 ThrType.tag    = 'Thr';
-ThrType.values = {Vox Clus};
+ThrType.values = {Vox ClusTFCE Clus};
 ThrType.val    = {Vox};
 ThrType.help   = {
     'Choose between voxel-wise and cluster-wise inference.'

--- a/config/snpm_bch_ui.m
+++ b/config/snpm_bch_ui.m
@@ -137,11 +137,25 @@ ST_now.help    = {
 		 };
 ST_now.def     = @(val)snpm_get_defaults('ST_U');
 
+% adding TFCE
+ST_tfce         = cfg_entry;
+ST_tfce.tag     = 'ST_tfce';
+ST_tfce.name    = 'Yes, do threshold-free cluster inference (fast)';
+ST_tfce.strtype = 'e';
+ST_tfce.num     = [1 4];
+ST_tfce.help    = {
+    'Cluster inference without setting cluster-forming threshold.'
+    ''
+    'Define height exponent, extent exponent, connectivity, step size, respectively. See Threshold-free Cluster Enhancement (Smith & Nichols, 2009) paper for details.'
+    };
+ST_tfce.def     = @(val)snpm_get_defaults('ST_tfce');
+
+
 ST         = cfg_choice;
 ST.tag     = 'ST';
 ST.name    = 'Cluster inference';
 ST.val     = {ST_none};
-ST.values  = {ST_none ST_later ST_now};
+ST.values  = {ST_none ST_tfce ST_later ST_now};
 ST.help    = {'','Cluster inference in SnPM requires a substantial addtional computational and (possible) disk space burden, and hence is not done by default.',...
 	      'If performing cluster size inference, you can choose to set the cluster-forming threshold later, in which case a large amount of information is written to disk on each permutation.',...
 	      'Alternatively, you can choose to set the cluster-forming threshold now (pre-computation); this requires no additional disk space.  However, if you decide you want a different cluster-forming threshold you have to completely re-run the analysis.'};

--- a/snpm_defaults.m
+++ b/snpm_defaults.m
@@ -20,6 +20,7 @@ global SnPMdefs
 SnPMdefs.STalpha = 0.01; % T values above this sig are save for ST analysis
 SnPMdefs.STprop  = 0.10; % 100*(1-STprop)%ile of observed Psuedo T values saved
 SnPMdefs.ST_U    = 2.03; % Default cluster-forming threshold set pre-analysis
+SnPMdefs.ST_tfce = [2 0.5 18 0.1]; % Height exponent, Extent exponent, Connectivity, Step size, respectively. See Threshold-free Cluster Enhancement (Smith & Nichols, 2009)
 
 % Work in "high memory" mode?
 %------------------------------------------------------------------------

--- a/snpm_pp.m
+++ b/snpm_pp.m
@@ -64,7 +64,7 @@ function snpm_pp(CWD,varargin)
 %
 % (3) WriteFiles: All image files have been written by snpm_cp, and there
 % is only one file that may be written here:  Users are asked 'write
-% filtered statistic image?'. 
+% filtered statistic image?'.
 %                           ----------------
 %
 % Next come parameters for the assessment of the statistic image...
@@ -74,15 +74,15 @@ function snpm_pp(CWD,varargin)
 %     the threshold as FWE-corrected('FWE'), FDR-corrected('FDR') or
 %     uncorrected('None').  A FWE threshold controls the chance of one or
 %     more false positives; a FDR threshold controls the expected
-%     fraction of false positives among the voxels detected. 
-%  
+%     fraction of false positives among the voxels detected.
+%
 %     Then you specify the threshold, the statistical significance
 %     level at which you wish to assess the evidence against the null
 %     hypothesis. In SPM this is called "filtering by corrected
 %     p-value".  SnPM will only show you voxels (& suprathreshold
 %     regions if you choose) that are significant based on the method you
 %     choose at level \alpha.  I.e. only voxels (& regions) with
-%     corrected (or uncorrected) p-value less than \alpha are shown to 
+%     corrected (or uncorrected) p-value less than \alpha are shown to
 %     you.
 %
 %     Setting \alpha to 1 will show you all voxels with a positive statistic.
@@ -126,7 +126,7 @@ function snpm_pp(CWD,varargin)
 % time, particularly for low thresholds or large numbers of
 % relabellings. Eventually, the Graphics window will come up and the
 % results displayed.
-%     
+%
 % - Results
 %=======================================================================
 %
@@ -148,7 +148,7 @@ function snpm_pp(CWD,varargin)
 % MIP is tabulated by clusters of voxels, showing the maximum voxel
 % within each cluster, along with at most three other local maxima
 % within the cluster. The table has the following columns:
-% 
+%
 %
 % At Cluster Level
 %
@@ -159,7 +159,7 @@ function snpm_pp(CWD,varargin)
 %   as or more extreme anywhere in the statistic image. This is the
 %   proportion of the permutation distribution of the maximal
 %   suprathreshold cluster size exceeding (or equalling) the observed
-%   size of the current cluster. 
+%   size of the current cluster.
 %
 % * k: The size (in voxels) of the cluster.
 %
@@ -203,7 +203,7 @@ function snpm_pp(CWD,varargin)
 %
 % * alpha: The test level specified.
 %
-% * Critical threshold: The critical statistic level. This is the value 
+% * Critical threshold: The critical statistic level. This is the value
 %   above which voxels are significant (corrected) at level \alpha.  It
 %   is computed as the 100(1-alpha)%-ile of the permutation
 %   distribution of the maximal statistic.
@@ -283,9 +283,10 @@ function snpm_pp(CWD,varargin)
 % CONT          Contrast (only one)
 % bVarSm        Flag for variance smoothing (Pseudo t-statistics)
 % sVarSm        Sring describing variance Smoothing (empty if bVarSm=0)
-% bST           Flag for collection of superthreshold info 
+% bST           Flag for collection of superthreshold info
+% bTFCE         Flag for calculating threshold-free cluster score
 % sDesign       Description of PlugIn design
-% 
+%
 % SnPM analysis & permutation distribution file:	SnPM.mat
 %-----------------------------------------------------------------------
 % - saved by snpm_cp
@@ -293,6 +294,7 @@ function snpm_pp(CWD,varargin)
 % V             Image file handles (see spm_vol)
 % df            Residual degrees of freedom of raw t-statistic
 % MaxT          2xnPerm matrix of [max;min] t-statistics per perm
+% MaxCSS         nPerm x 2 matrix of [max;min] cluster-like support score
 % ST_Ut         Threshold above which suprathreshold info was collected.
 %               Voxel locations, t and perm are saved in SnPM_ST.mat for
 %               t's greater than ST_Ut. ST_Ut=Inf if not saving STCdata
@@ -328,9 +330,9 @@ fprintf('\nSnPM: snpm_pp\n'),fprintf('%c','='*ones(1,72)),fprintf('\n')
 %-Initialise variables & constants
 %-----------------------------------------------------------------------
 tol = 1e-4;	% Tolerance for comparing real numbers
-		% Two reals with abs(a-b)<tol are considered equal
-		% ( Reals have to be compared for equality when        )
-		% ( computing FWE-corrected p-values                   )
+% Two reals with abs(a-b)<tol are considered equal
+% ( Reals have to be compared for equality when        )
+% ( computing FWE-corrected p-values                   )
 
 %-SetUp figure window
 %-----------------------------------------------------------------------
@@ -345,23 +347,23 @@ set(Finter,'Name','SnPM PostProcess');
 %=======================================================================
 % Get analysis directory
 if nargin==0
-  tmp  = spm_select(1,'SnPM.mat','Select SnPM.mat for analysis...');
-  CWD  = spm_str_manip(tmp,'hd');
+    tmp  = spm_select(1,'SnPM.mat','Select SnPM.mat for analysis...');
+    CWD  = spm_str_manip(tmp,'hd');
 end
 if nargin>1
-  job=varargin{1};
-  BATCH=true;
+    job=varargin{1};
+    BATCH=true;
 else
-  BATCH=false;
+    BATCH=false;
 end
 
 %-Skip reports in BATCH; will create them later
 if BATCH
-  Report = {job.Report};
+    Report = {job.Report};
 else
-  % Only can specify multiple reports outside of BATCH mode; otherwise the results will fly by,
-  % one after another without pausing
-  Report = {'FWEreport','FDRreport','MIPtable'};
+    % Only can specify multiple reports outside of BATCH mode; otherwise the results will fly by,
+    % one after another without pausing
+    Report = {'FWEreport','FDRreport','MIPtable'};
 end
 
 
@@ -374,19 +376,19 @@ load(fullfile(CWD,'SnPMucp'))
 %-Ask whether positive or negative effects be analysed
 %-----------------------------------------------------------------------
 if BATCH
-  if STAT == 'T'
-    bNeg = job.Tsign==-1;
-  else
-    bNeg = 0;
-  end
+    if STAT == 'T'
+        bNeg = job.Tsign==-1;
+    else
+        bNeg = 0;
+    end
 else
-  if STAT == 'T'
-    bNeg = spm_input('Positive or negative effects?',1,'b','+ve|-ve',[0,1],1);
-  else
-    bNeg = 0;  
-    str = 'Positive effects';
-    spm_input('F-statistic, so only:','+1','b',str,1);
-  end
+    if STAT == 'T'
+        bNeg = spm_input('Positive or negative effects?',1,'b','+ve|-ve',[0,1],1);
+    else
+        bNeg = 0;
+        str = 'Positive effects';
+        spm_input('F-statistic, so only:','+1','b',str,1);
+    end
 end
 
 %-Take MaxT for increases or decreases according to bNeg
@@ -404,8 +406,8 @@ XYZ0=XYZ;
 %-Negate if looking at negative contrast
 %-----------------------------------------------------------------------
 if bNeg
-	SnPMt    = -SnPMt;
-	CONT     = -CONT;
+    SnPMt    = -SnPMt;
+    CONT     = -CONT;
 end
 
 %-Get ORIGIN, etc
@@ -426,10 +428,10 @@ Vs0 = V(1);
 % 	     'descrip',	'');
 
 % Process Nonparmaetric P-values
-if bNeg 
-  % Here, nPermReal has already been doubled if bhPerms=1
-  SnPMucp = 1+1/nPermReal-SnPMucp;
-end  
+if bNeg
+    % Here, nPermReal has already been doubled if bhPerms=1
+    SnPMucp = 1+1/nPermReal-SnPMucp;
+end
 sSnPMucp = sort(SnPMucp);
 
 
@@ -437,25 +439,27 @@ sSnPMucp = sort(SnPMucp);
 %-Write out filtered statistic image?  (Get's done later)
 %-----------------------------------------------------------------------
 if BATCH
-  if isfield(job.WriteFiltImg,'WF_no')
-    WrtFlt=0;
-  else
-    WrtFlt=1;
-    WrtFltFn=job.WriteFiltImg.name;
-    
-    if isempty(spm_str_manip(WrtFltFn, 'e'))
-        WrtFltFn = [WrtFltFn '.nii'];
+    if isfield(job.WriteFiltImg,'WF_no')
+        WrtFlt=0;
+    else
+        WrtFlt=1;
+        WrtFltFn=job.WriteFiltImg.name;
+        
+        if isempty(spm_str_manip(WrtFltFn, 'e'))
+            WrtFltFn = [WrtFltFn '.nii'];
+        end
     end
-  end
 else
-  WrtFlt = spm_input('Write filtered statistic img?','+1','y/n',[1,0],2);
-  if WrtFlt
-    WrtFltFn = 'SnPMt_filtered';
-    WrtFltFn=spm_input('Filename ?','+1','s',WrtFltFn);
-    WrtFltFn = [WrtFltFn, '.img'];
-  end
+    WrtFlt = spm_input('Write filtered statistic img?','+1','y/n',[1,0],2);
+    if WrtFlt
+        WrtFltFn = 'SnPMt_filtered';
+        WrtFltFn=spm_input('Filename ?','+1','s',WrtFltFn);
+        WrtFltFn = [WrtFltFn, '.img'];
+    end
 end
 
+% TFCE flag - currently only available in BATCH mode
+procTFCE = 0;
 
 %-Get inference parameters
 %=======================================================================
@@ -464,13 +468,13 @@ end
 % [Root]     > .Thr
 % Voxel-Level    > .Vox
 % . Significance  > .VoxSig
-% . . Uncorrected Nonparametric P | Uncorrected T or F | FDR Corrected | FWE Corrected 
+% . . Uncorrected Nonparametric P | Uncorrected T or F | FDR Corrected | FWE Corrected
 %    > .Pth                            .TFth                .FDRth          .FWEth
 % Cluster-Level  > .Clus
 % . Cluster size statistic > .ClusSize
 % . . Cluster-Forming Threshold > .CFth
 % . . Significance Level > .ClusSig
-% . . . Uncorrected k | FWE Corrected 
+% . . . Uncorrected k | FWE Corrected
 %   >   .Cth           .FWEthC
 
 %-Get corrected threshold
@@ -478,42 +482,88 @@ end
 u         = NaN;   % Statistic Image threshold
 alpha_ucp = NaN;   % Uncorrected P-value image threshold
 C_MaxT    = NaN;   % Statistic image threshold set by alph_FWE
+C_MaxCSS    = NaN; % Cluster-like support score threshold set by alph_FWE
 C_STCS    = NaN;   % Cluster size threshold (set directly by uncorrected
-		   % threshold or by alph_FWE)
-		   
+% threshold or by alph_FWE)
+
 alph_FWE  = NaN;   % FWE rate of a specified u threshold
 alph_FDR  = NaN;   % FDR rate of a specified alpha_ucp
-  
+
 if BATCH
     bSpatEx = isfield(job.Thr,'Clus');
-    if ~bSpatEx
+    if isfield(job.Thr,'ClusTFCE')
+        if bTFCE
+            procTFCE = 1;
+        else
+            error(['SnPM:NoTFCEInfo', 'ERROR: Threshold-free cluster inference requested, but no TFCE information saved.\n',...
+                'Re-configure analysis changing "Cluster inference" to "Yes, do threshold-free clustere inference" and re-run.\n'])
+        end
+    end
+    if ~or(bSpatEx, procTFCE) 
         % Voxel-wise inference
         tmp = fieldnames(job.Thr.Vox.VoxSig);
         switch tmp{1}
-        case 'Pth'
-            alpha_ucp = BoundCheck(job.Thr.Vox.VoxSig.Pth,[0 1],'Invalid Uncorrected P');
-            alph_FDR  = snpm_P_FDR(alpha_ucp,[],'P',[],sSnPMucp');
-        case 'TFth'
-            u         = BoundCheck(job.Thr.Vox.VoxSig.TFth,[0 Inf],'Negative Threshold!');
-            alph_FWE  = sum(MaxT > u -tol) / nPermReal;
-        case 'FDRth'
-            alph_FDR  = BoundCheck(job.Thr.Vox.VoxSig.FDRth,[0 1],'Invalid FDR level');
-            alpha_ucp = snpm_uc_FDR(alph_FDR,[],'P',[],sSnPMucp');
-        case 'FWEth'
-            alph_FWE  = BoundCheck(job.Thr.Vox.VoxSig.FWEth,[0 1],'Invalid FWE level');
-            iFWE      = ceil((1-alph_FWE)*nPermReal);
-            if alph_FWE<1
-                C_MaxT=StMaxT(iFWE);
-            else
-                C_MaxT = 0;
-            end
-            u = C_MaxT;
+            case 'Pth'
+                alpha_ucp = BoundCheck(job.Thr.Vox.VoxSig.Pth,[0 1],'Invalid Uncorrected P');
+                alph_FDR  = snpm_P_FDR(alpha_ucp,[],'P',[],sSnPMucp');
+            case 'TFth'
+                u         = BoundCheck(job.Thr.Vox.VoxSig.TFth,[0 Inf],'Negative Threshold!');
+                alph_FWE  = sum(MaxT > u -tol) / nPermReal;
+            case 'FDRth'
+                alph_FDR  = BoundCheck(job.Thr.Vox.VoxSig.FDRth,[0 1],'Invalid FDR level');
+                alpha_ucp = snpm_uc_FDR(alph_FDR,[],'P',[],sSnPMucp');
+            case 'FWEth'
+                alph_FWE  = BoundCheck(job.Thr.Vox.VoxSig.FWEth,[0 1],'Invalid FWE level');
+                iFWE      = ceil((1-alph_FWE)*nPermReal);
+                if alph_FWE<1
+                    C_MaxT=StMaxT(iFWE);
+                else
+                    C_MaxT = 0;
+                end
+                u = C_MaxT;
         end
+        
+    elseif procTFCE 
+        % threshold-free cluster inference
+        % calculate the observed cluster-like support score
+        idx_vol = NaN(1,prod(DIM));
+        idx_vol(spm_xyz2e(XYZ,V)) = (1:length(SnPMt));
+        [~, vol2vec] = sort(idx_vol);
+        
+        t_vol = zeros(1,prod(DIM))*NaN;
+        t_vol(spm_xyz2e(XYZ,V)) = SnPMt;
+        t_vol = reshape(t_vol,DIM);
+        
+        % redo TFCE and convert it to the vector form,
+        % which should be in the same space as SnPMt
+        height_exp = param_TFCE(1);
+        extent_exp = param_TFCE(2);
+        connect = param_TFCE(3);
+        step_size = param_TFCE(4);
+        css_vol = snpm_tfce(t_vol, height_exp, extent_exp, connect, step_size);
+        css_vol = reshape(css_vol, 1, []);
+        css_vec = css_vol(vol2vec);
+        css_vec = css_vec(1:length(SnPMt));
+        
+        %-Take MaxCSS for increases or decreases according to bNeg
+        MaxCSS = MaxCSS(:, bNeg+1);
+        StMaxCSS = sort(MaxCSS);
+        
+        % for TFCE, only FWE correction is available (for now)
+        alph_FWE  = BoundCheck(job.Thr.ClusTFCE.FWEthCSS,[0 1],'Invalid FWE level');
+        iFWE      = ceil((1-alph_FWE)*nPermReal);
+        if alph_FWE<1
+            C_MaxCSS=StMaxCSS(iFWE);
+        else
+            C_MaxCSS = 0;
+        end
+        u = C_MaxCSS;
+        
     else
         % Cluster-wise inference
         if exist(fullfile(CWD,'SnPM_ST.mat'))~=2 & exist(fullfile(CWD,'STCS.mat'))~=2
             error(['SnPM:NoClusterInfo', 'ERROR: Cluster-wise inference requested, but no cluster information saved.\n',...
-            'Re-configure analysis changing "Cluster inference" to "Yes" and re-run.\n'])
+                'Re-configure analysis changing "Cluster inference" to "Yes" and re-run.\n'])
         end
         %%% Sort out the cluster-forming threshold
         if pU_ST_Ut==-1  % No threshold was set in snpm_ui.
@@ -527,7 +577,7 @@ if BATCH
                 error('SnPM:InvalidClusterFormingThresh', 'ERROR: Cluster-forming threshold must be strictly positive.\nRe-run results with a cluster-forming threshold greater than 0.\n')
             end
             if bVarSm
-                %-If using pseudo-statistics then can't use (uncorrected) 
+                %-If using pseudo-statistics then can't use (uncorrected)
                 % upper tail p-values to specify primary threshold
                 pCFth = NaN;
                 if (CFth<1)
@@ -539,7 +589,7 @@ if BATCH
                     pCFth = CFth;
                     CFth = spm_invNcdf(1-CFth);
                     
-%                     error(sprintf('ERROR: Cluster-forming threshold specified as a P-value (%g), but uncorrected P-values are unavailable for the pseudo t (smoothed variance t-test).  \nRe-run results with a cluster-forming threshold greater than 1.\n',ST_Ut))
+                    %                     error(sprintf('ERROR: Cluster-forming threshold specified as a P-value (%g), but uncorrected P-values are unavailable for the pseudo t (smoothed variance t-test).  \nRe-run results with a cluster-forming threshold greater than 1.\n',ST_Ut))
                 end
                 
                 if (CFth < ST_Ut)%(CFth>=ST_Ut-tol)
@@ -558,10 +608,10 @@ if BATCH
                 else
                     pCFth = NaN;
                     if (abs(CFth-ST_Ut)<=tol)
-                    CFth=ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
+                        CFth=ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
                     end
                 end
-
+                
                 if (CFth < ST_Ut) %(CFth>=ST_Ut-tol)
                     if isnan(pCFth) % statistic-value cluster-forming threshold
                         error('SnPM:InvalidClusterFormingThresh', sprintf('ERROR: Cluster-forming threshold of %0.2f specified, but statistic image information only saved for %0.2f and greater. \nRe-run results with a cluster-forming threshold of %0.2f or higher.  (Alternatively, increase SnPMdefs.STalpha in snpm_defaults.m, re-start SnPM, and re-compute analysis.)\n',CFth,ST_Ut,ST_Ut))
@@ -573,7 +623,7 @@ if BATCH
             if (abs(CFth-ST_Ut)<=tol)
                 CFth = ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
             end
-                ST_Ut = CFth;
+            ST_Ut = CFth;
         else % Threshold *was* set in snpm_ui.
             if ~isnan(job.Thr.Clus.ClusSize.CFth)
                 error('SnPM:InvalidClusterFormingThresh', sprintf('ERROR: Cluster-forming threshold of T=%0.2f was already set during analysis configuration; hence, in results, cluster-forming threshold must be left as "NaN".\nRe-run results with cluster-forming threshold set to NaN.\n',ST_Ut))
@@ -592,141 +642,179 @@ if BATCH
                 iFWE      = ceil((1-alph_FWE)*nPermReal);
         end
     end % END: Cluster-wise inference
-
+    
 else  % GUI, interative inference specification
-
-  str_img =[STAT,'|P'];
-  switch spm_input('Results for which img?','+1','b',str_img,[],1)
     
-   case 'P' % Use the P-image
-    bSpatEx = 0; % Cluster-wise inference won't be performed anyway. 
-    str = 'FDR|None';
-    switch spm_input('Use corrected threshold?','+1','b',str,[],1)
-      
-     case 'FDR' % False discovery rate
-      %---------------------------------------------------------------	
-      alph_FDR = spm_input('FDR-Corrected p value threshold','+0','r',0.05,1,[0,1]);
-      alpha_ucp = snpm_uc_FDR(alph_FDR,[],'P',[],sSnPMucp');
-		
-     otherwise  %-Uncorrected: no adjustment
-      %%%% Now ask: Threshold statistic image or Uncorr P-value Image ?
-      %%%% If stats image, maybe do ST, no FDR-level of thresh;
-      %%%% If P-value image, no ST, can find FDR-level of thresh
-
-      % p for conjunctions is p of the conjunction SPM
-      %---------------------------------------------------------------
-      alpha_ucp = spm_input('Uncorrected p value threshold','+0','r',0.01,1,[0,1]);
-      alph_FDR = snpm_P_FDR(alpha_ucp,[],'P',[],sSnPMucp');
-    end 
-  
-   case STAT % Use the T-image
-    %-Ask whether SupraThreshold cluster size test required
-    %----------------------------------------------------------------------- 
-    %-To have cluster size inference, need
-    %  1. Spatial extent information was collected (bST=1),
-    %  2. SnPM_ST.mat or STCS.mat file exists
-    bSpatEx = bST & (exist(fullfile(CWD,'SnPM_ST.mat'))==2|exist(fullfile(CWD,'STCS.mat'))==2);
-    
-    if bSpatEx
-      str = 'Voxelwise|Clusterwise';
-      bSpatEx = spm_input('Inference method?','+1','b',str,[1 2],1)==2;
-    else
-      str = 'Voxelwise';
-      spm_input('Inference method:','+1','b',str,1);
+    str_img =[STAT,'|P'];
+    switch spm_input('Results for which img?','+1','b',str_img,[],1)
+        
+        case 'P' % Use the P-image
+            bSpatEx = 0; % Cluster-wise inference won't be performed anyway.
+            str = 'FDR|None';
+            switch spm_input('Use corrected threshold?','+1','b',str,[],1)
+                
+                case 'FDR' % False discovery rate
+                    %---------------------------------------------------------------
+                    alph_FDR = spm_input('FDR-Corrected p value threshold','+0','r',0.05,1,[0,1]);
+                    alpha_ucp = snpm_uc_FDR(alph_FDR,[],'P',[],sSnPMucp');
+                    
+                otherwise  %-Uncorrected: no adjustment
+                    %%%% Now ask: Threshold statistic image or Uncorr P-value Image ?
+                    %%%% If stats image, maybe do ST, no FDR-level of thresh;
+                    %%%% If P-value image, no ST, can find FDR-level of thresh
+                    
+                    % p for conjunctions is p of the conjunction SPM
+                    %---------------------------------------------------------------
+                    alpha_ucp = spm_input('Uncorrected p value threshold','+0','r',0.01,1,[0,1]);
+                    alph_FDR = snpm_P_FDR(alpha_ucp,[],'P',[],sSnPMucp');
+            end
+            
+        case STAT % Use the T-image
+            %-Ask whether SupraThreshold cluster size test required
+            %-----------------------------------------------------------------------
+            %-To have cluster size inference, need
+            %  1. Spatial extent information was collected (bST=1),
+            %  2. SnPM_ST.mat or STCS.mat file exists
+            bSpatEx = bST & (exist(fullfile(CWD,'SnPM_ST.mat'))==2|exist(fullfile(CWD,'STCS.mat'))==2);
+            
+            if bSpatEx
+                str = 'Voxelwise|Clusterwise';
+                bSpatEx = spm_input('Inference method?','+1','b',str,[1 2],1)==2;
+            elseif bTFCE
+                str = 'Voxelwise|Cluster(TFCE)';
+                procTFCE = spm_input('Inference method?','+1','b',str,[1 2],1)==2;
+            else
+                str = 'Voxelwise';
+                spm_input('Inference method:','+1','b',str,1);
+            end
+            
+            if ~or(bSpatEx, procTFCE) % Voxel-wise inference
+                str = 'FWE|None';
+                switch spm_input('Voxelwise: Use corrected thresh?','+1','b',str,[],1)
+                    
+                    case 'FWE' % family-wise false positive rate
+                        %---------------------------------------------------------------
+                        alph_FWE  = spm_input('FWE-Corrected p value threshold','+0','r',0.05,1,[0,1]);
+                        iFWE=ceil((1-alph_FWE)*nPermReal);
+                        if alph_FWE<1
+                            C_MaxT=StMaxT(iFWE);
+                        else
+                            C_MaxT = 0;
+                        end
+                        u = C_MaxT;
+                        
+                    otherwise  %-NB: no adjustment
+                        %%%% Now ask: Threshold statistic image or Uncorr P-value Image ?
+                        %%%% If stats image, maybe do ST, no FDR-level of thresh;
+                        %%%% If P-value image, no ST, can find FDR-level of thresh
+                        
+                        % p for conjunctions is p of the conjunction SPM
+                        %---------------------------------------------------------------
+                        if bVarSm, str = 'pseudo t'; else, str = sprintf('t_{%d}',df); end
+                        u  = spm_input(['threshold (',str,')'],'+0','r',0.01,1,[0,Inf]);
+                        alph_FWE = sum(MaxT > u -tol) / nPermReal;
+                end
+                
+            elseif procTFCE % threshold-free cluster inference
+                
+                alph_FWE  = spm_input('FWE-Corrected p value threshold','+0','r',0.05,1,[0,1]);
+                iFWE=ceil((1-alph_FWE)*nPermReal);
+                %-Take MaxCSS for increases or decreases according to bNeg
+                MaxCSS = MaxCSS(:, bNeg+1);
+                StMaxCSS = sort(MaxCSS);
+                if alph_FWE<1
+                    C_MaxCSS=StMaxCSS(iFWE);
+                else
+                    C_MaxCSS = 0;
+                end
+                u = C_MaxCSS;
+                
+                % make the CSS vector available for below
+                % calculate the observed cluster-like support score
+                idx_vol = NaN(1,prod(DIM));
+                idx_vol(spm_xyz2e(XYZ,V)) = (1:length(SnPMt));
+                [~, vol2vec] = sort(idx_vol);
+                
+                t_vol = zeros(1,prod(DIM))*NaN;
+                t_vol(spm_xyz2e(XYZ,V)) = SnPMt;
+                t_vol = reshape(t_vol,DIM);
+                
+                % redo TFCE and convert it to the vector form,
+                % which should be in the same space as SnPMt
+                height_exp = param_TFCE(1);
+                extent_exp = param_TFCE(2);
+                connect = param_TFCE(3);
+                step_size = param_TFCE(4);
+                css_vol = snpm_tfce(t_vol, height_exp, extent_exp, connect, step_size);
+                css_vol = reshape(css_vol, 1, []);
+                css_vec = css_vol(vol2vec);
+                css_vec = css_vec(1:length(SnPMt));
+               
+            else % Cluster-wise inference
+                
+                if pU_ST_Ut==-1  % No threshold was set in snpm_ui.
+                    %-Get primary threshold for STC analysis if requested
+                    %-----------------------------------------------------------------------
+                    % Save original ST_Ut
+                    ST_Ut_0 = ST_Ut;
+                    %-Threshold must be greater or equal to that (ST_Ut) used to collect
+                    % suprathreshold data in snpm_cp
+                    %-If a test level alpha has been set, then it there's no sense in having
+                    % the threshold greater than C_MaxT, above which voxels are individually
+                    % significant
+                    tmp = 0;
+                    if bVarSm
+                        %-If using pseudo-statistics then can't use (uncorrected)
+                        % upper tail p-values to specify primary threshold
+                        while ~(tmp>=ST_Ut-tol)
+                            tmp = spm_input(sprintf(...
+                                'Clus-def thresh(pseudo t>%4.2f)',ST_Ut),'+0');
+                        end
+                        if (abs(tmp-ST_Ut)<=tol)
+                            tmp=ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
+                        end
+                    else
+                        %-Statistic image is t with df degrees of freedom
+                        p_ST_Ut  = STalpha;
+                        while ~( tmp>=ST_Ut-tol | (tmp>0 & tmp<=p_ST_Ut))
+                            tmp = spm_input(sprintf(...
+                                'Clus-def thresh(p<=%4.2fIt>=%4.2f)',p_ST_Ut,ST_Ut),'+0','r',ST_Ut,1);
+                        end
+                        clear p_ST_Ut
+                        if (tmp < 1)
+                            tmp = spm_invTcdf(1-tmp,df);
+                        else
+                            if (abs(tmp-ST_Ut)<=tol)
+                                tmp=ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
+                            end
+                        end
+                    end
+                    ST_Ut = tmp;
+                end
+                u=ST_Ut; % Flag use of a statistic-value threshold
+                
+                str = 'FWE|Uncorr';
+                switch spm_input('Clusterwise: Use corrected thresh?','+1','b',str,[],1)
+                    case 'FWE' % family-wise false positive rate
+                        %---------------------------------------------------------------
+                        alph_FWE  = spm_input('FWE-Corrected p value threshold','+0','r',0.05,1,[0,1]);
+                        iFWE=ceil((1-alph_FWE)*nPermReal);
+                        
+                    case 'Uncorr' %Uncorrected cluster size threshold
+                        
+                        str = 'ClusterSize|P-value';
+                        switch spm_input('Define uncorrected','+1','b',str,[],1)
+                            
+                            case 'ClusterSize'
+                                C_STCS = spm_input('Uncorr cluster size threshold','+0','w',0,1);
+                                
+                            case 'P-value'
+                                alpha_ucp = spm_input('Uncorrected p value threshold','+0','r',0.01,1,[0,1]);
+                                
+                        end
+                end
+            end
     end
-    
-    if ~bSpatEx % Voxel-wise inference
-      str = 'FWE|None';
-      switch spm_input('Voxelwise: Use corrected thresh?','+1','b',str,[],1)
-	
-       case 'FWE' % family-wise false positive rate
-	%---------------------------------------------------------------
-	alph_FWE  = spm_input('FWE-Corrected p value threshold','+0','r',0.05,1,[0,1]);
-	iFWE=ceil((1-alph_FWE)*nPermReal);
-	if alph_FWE<1
-	  C_MaxT=StMaxT(iFWE);
-	else
-	  C_MaxT = 0;
-	end
-	u = C_MaxT;
-	
-       otherwise  %-NB: no adjustment
-	%%%% Now ask: Threshold statistic image or Uncorr P-value Image ?
-	%%%% If stats image, maybe do ST, no FDR-level of thresh;
-	%%%% If P-value image, no ST, can find FDR-level of thresh
-
-	% p for conjunctions is p of the conjunction SPM
-   	%---------------------------------------------------------------
-	if bVarSm, str = 'pseudo t'; else, str = sprintf('t_{%d}',df); end
-	u  = spm_input(['threshold (',str,')'],'+0','r',0.01,1,[0,Inf]);
-	alph_FWE = sum(MaxT > u -tol) / nPermReal;
-      end
-    
-    else % Cluster-wise inference
-    
-      if pU_ST_Ut==-1  % No threshold was set in snpm_ui.
-        %-Get primary threshold for STC analysis if requested
-	%-----------------------------------------------------------------------
-	% Save original ST_Ut
-	ST_Ut_0 = ST_Ut;
-	%-Threshold must be greater or equal to that (ST_Ut) used to collect
-	% suprathreshold data in snpm_cp
-	%-If a test level alpha has been set, then it there's no sense in having
-	% the threshold greater than C_MaxT, above which voxels are individually 
-	% significant
-	tmp = 0;
-	if bVarSm
-	  %-If using pseudo-statistics then can't use (uncorrected) 
-	  % upper tail p-values to specify primary threshold
-	  while ~(tmp>=ST_Ut-tol)
-	    tmp = spm_input(sprintf(...
-		'Clus-def thresh(pseudo t>%4.2f)',ST_Ut),'+0');
-	  end
-	  if (abs(tmp-ST_Ut)<=tol)
-	  tmp=ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
-	  end
-	else
-	  %-Statistic image is t with df degrees of freedom
-	  p_ST_Ut  = STalpha;
-	  while ~( tmp>=ST_Ut-tol | (tmp>0 & tmp<=p_ST_Ut))
-	    tmp = spm_input(sprintf(...
-		'Clus-def thresh(p<=%4.2fIt>=%4.2f)',p_ST_Ut,ST_Ut),'+0','r',ST_Ut,1); 
-	  end
-	  clear p_ST_Ut
-	  if (tmp < 1)
-	    tmp = spm_invTcdf(1-tmp,df);
-	  else 
-	    if (abs(tmp-ST_Ut)<=tol)
-	      tmp=ST_Ut; % If tmp is very close to ST_Ut, set tmp equal to ST_Ut.
-	    end
-	  end
-	end
-	ST_Ut = tmp;
-      end
-      u=ST_Ut; % Flag use of a statistic-value threshold
-
-      str = 'FWE|Uncorr';
-      switch spm_input('Clusterwise: Use corrected thresh?','+1','b',str,[],1)
-       case 'FWE' % family-wise false positive rate
-        %---------------------------------------------------------------
-	alph_FWE  = spm_input('FWE-Corrected p value threshold','+0','r',0.05,1,[0,1]);
-	iFWE=ceil((1-alph_FWE)*nPermReal);
-	
-       case 'Uncorr' %Uncorrected cluster size threshold
-	
-	str = 'ClusterSize|P-value';
-	switch spm_input('Define uncorrected','+1','b',str,[],1)
-	  
-	 case 'ClusterSize'
-	  C_STCS = spm_input('Uncorr cluster size threshold','+0','w',0,1);
-	  
-	 case 'P-value'
-	  alpha_ucp = spm_input('Uncorrected p value threshold','+0','r',0.01,1,[0,1]);
-	  
-	end
-      end
-    end	
-  end
 end
 
 
@@ -741,25 +829,29 @@ end
 %               alph_FDR and is used as the threshold.
 %   case 'None': alpha_ucp is set by spm_input; alph_FDR is calculated from
 %                alpha_ucp. alpha_ucp is used as the threshold.
-% 
+%
 % 2) T
 %
 %   a) Voxel-wise
 %      case 'FWE': alph_FWE is set by spm_input; u=C_MaxT; iFWE is
 %                  calculated. u is used as the threshold.
 %      case 'None': u is set by spm_input; alph_FWE is calculated from u.
-%                   u is used as the threshold. 
+%                   u is used as the threshold.
 %
-%   b) Cluster-wise
+%   b) Threshold-free cluster inference
+%      case 'FWE': alph_FWE is set by spm_input; u=C_MaxCSS; iFWE is
+%                  calculated. u is used as the threshold.
+%
+%   c) Cluster-wise with a threshold
 %      If cluster defining threshold not set, ask for pU_ST_Ut
 %      case 'FWE': alph_FWE is set by spm_input; iFWE is calculated from
 %                  alph_FWE. C_STCS is calculated from iFWE and is used
-%                  as the threshold. 
-%      case 'Uncorr': 
-%               i) 'ClusterSize', C_STCS is defined directly and used as  
-%                   the threshold; 
+%                  as the threshold.
+%      case 'Uncorr':
+%               i) 'ClusterSize', C_STCS is defined directly and used as
+%                   the threshold;
 %               ii) 'P-value', alpha_ucp is set by spm_input. C_STCS is
-%                   calculated from alpha_ucp and used as the threshold. 
+%                   calculated from alpha_ucp and used as the threshold.
 %
 
 
@@ -773,220 +865,220 @@ set(Finter,'Pointer','Watch')
 %-Calculate critical Suprathreshold Cluster Size
 %=======================================================================
 if bSpatEx
-	fprintf('Working on spatial extent...\n');
-	%-Compute suprathreshold voxels - check there are some
-	%---------------------------------------------------------------
-	fprintf('\tComputing suprathreshold voxels...');
-	Q     = find(SnPMt > ST_Ut);
-	SnPMt = SnPMt(Q);
-	XYZ   = XYZ(:,Q);
-	
-	if isempty(Q)
-	  set(Finter,'Pointer','Arrow')
-	  figure(Fgraph)
-	  axis off
-	  text(0,0.97,CWD,'Fontsize',16,'FontWeight','Bold');
-	  str=sprintf('No voxels above threshold %4.2f\n',ST_Ut);
-	  text(0,0.93,str);
-	  fprintf(['WARNING: ' str])
-	  if length(strmatch('FWEreport',Report))>0
-	    ShowDist(MaxT,C_MaxT,alph_FWE,[],[],[],'max');
-	    if ~BATCH
-	      if spm_input('Review permutation distributions.',1,'bd',...
-			   'Print & Continue|Continue',[1,0],1)
-		spm_print
-	      end
-	      spm_clf(Fgraph)
-	    end
-	  end
-	  if length(strmatch('FDRreport',Report))>0
-	    axis off
-	    text(0,0.97,'Uncorrected P Permutation Distributions','Fontsize',16,'FontWeight',...
-		 'Bold');
-	    ShowDist(SnPMucp,alpha_ucp,alph_FDR,[],[],[],'uncor');
-	    if ~BATCH
-	      if spm_input('Review permutation distributions.',1,'bd',...
-			   'Print|Done',[1,0],1)
-		spm_print
-	      end
-	    end
-	  end
-	  return
-	end
-	fprintf('done\n')
-
-	%-Load & condition statistics
-	%---------------------------------------------------------------
-        if pU_ST_Ut==-1 % No threshold was set in snpm_ui.
-	  fprintf('\tLoading & conditioning SupraThreshold statistics...');
-      try
-        load(fullfile(CWD,'SnPM_ST'))
-      catch exception
-          if strcmp(exception.identifier, 'MATLAB:load:unableToReadMatFile')
-              warning('SnPM:SnPMSTFileNotLOaded', ...
-                  ['SnPM_ST file can not be loaded. Consider using' ...
-                  ' ''set cluster-forming threshold now (fast)'' option' ...
-                  ' in SnPM ''Specify''.']);
-          end
-          % Rethrow exception           
-          throw(exception)
-      end
-	  %-SnPM_ST stores columns of [x;y;z;abs(t);perm] with perm negative
-	  % where the exceedence was t < -ST_Ut_0
-	  %-Trim statistics according to threshold ST_Ut, if ST_Ut > ST_Ut_0
-	  tmp = find(SnPM_ST(4,:)>ST_Ut);
-	  SnPM_ST = SnPM_ST(:,tmp);
-	  clear tmp;	    
-	  
-	  SnPM_ST_Pos = SnPM_ST(:,SnPM_ST(5,:)>0);
-	  SnPM_ST_Neg = SnPM_ST(:,SnPM_ST(5,:)<0);
-	  SnPM_ST_Neg(5,:) = -SnPM_ST_Neg(5,:);
-	  
-	  fprintf('done\n')
-	  
-	  %-Calculate distribution of Maximum SupraThreshold Cluster size
-	  %---------------------------------------------------------------
-	  fprintf('\tComputing dist. of max SupraThreshold cluster size: ');
-	  STCS = snpm_STcalc('init',nPerm); 
-	  fprintf('\nPerms left:     ');
-	  for i = nPerm:-1:1
-	    if (rem(i,10)==0)
-	      fprintf('\b\b\b\b%-4u',i)
-	      drawnow
-	    end
-	    
-	    if STAT== 'F'
-	      loop = 1;
-	    else
-	      loop = 1:2;
-	    end
-	    
-        for isPos= loop  %1 for positive; 2 for negative
-            if isPos==1
-                SnPM_ST = SnPM_ST_Pos;
-            else
-                SnPM_ST = SnPM_ST_Neg;
-            end
-            tQ = (SnPM_ST(5,:)==i);
-            if any(tQ)
-                %-Compute cluster labellings for this perm
-                Locs_mm = SnPM_ST(1:3,tQ);
-                Locs_mm (4,:) = 1;
-                Locs_vox = IMAT * Locs_mm;
-                
-                % Sometimes Locs_vox are not exactly integers and this raises an
-                % error later in the code. Here check that the values are
-                % integers with respect to a level of absolute tolerance (~10^-14)
-                % and enforce Locs_vox to be integers.
-                % (As in snpm_cp)                
-                diffWithRounded = max(abs(Locs_vox(:)-round(Locs_vox(:))));
-                tolerance = 10^-10;
-                if diffWithRounded > tolerance
-                 Locs_vox_alter = MAT\Locs_mm;
-                 diffWithRounded_alter = max(abs(Locs_vox_alter(:)-round(Locs_vox(:))));
-                 error('SnPM:NonIntegerLocsvox', ['''Locs_vox'' must be integers (difference is ' num2str(diffWithRounded) ...
-                     ' or ' num2str(diffWithRounded_alter) ')']);
-                else
-                 Locs_vox = round(Locs_vox); 
+    fprintf('Working on spatial extent...\n');
+    %-Compute suprathreshold voxels - check there are some
+    %---------------------------------------------------------------
+    fprintf('\tComputing suprathreshold voxels...');
+    Q     = find(SnPMt > ST_Ut);
+    SnPMt = SnPMt(Q);
+    XYZ   = XYZ(:,Q);
+    
+    if isempty(Q)
+        set(Finter,'Pointer','Arrow')
+        figure(Fgraph)
+        axis off
+        text(0,0.97,CWD,'Fontsize',16,'FontWeight','Bold');
+        str=sprintf('No voxels above threshold %4.2f\n',ST_Ut);
+        text(0,0.93,str);
+        fprintf(['WARNING: ' str])
+        if length(strmatch('FWEreport',Report))>0
+            ShowDist(MaxT,C_MaxT,alph_FWE,[],[],[],'max');
+            if ~BATCH
+                if spm_input('Review permutation distributions.',1,'bd',...
+                        'Print & Continue|Continue',[1,0],1)
+                    spm_print
                 end
-
-                STCS = snpm_STcalc('update',STCS, SnPM_ST(4,tQ),...
-                   Locs_vox(1:3,:),isPos,i,ST_Ut,df);
+                spm_clf(Fgraph)
             end
-            if i==1
-                %-Save perm 1 stats for use later - [X;Y;Z;T;perm;STCno]
-                tmp = spm_clusters(Locs_vox(1:3,:));
+        end
+        if length(strmatch('FDRreport',Report))>0
+            axis off
+            text(0,0.97,'Uncorrected P Permutation Distributions','Fontsize',16,'FontWeight',...
+                'Bold');
+            ShowDist(SnPMucp,alpha_ucp,alph_FDR,[],[],[],'uncor');
+            if ~BATCH
+                if spm_input('Review permutation distributions.',1,'bd',...
+                        'Print|Done',[1,0],1)
+                    spm_print
+                end
+            end
+        end
+        return
+    end
+    fprintf('done\n')
+    
+    %-Load & condition statistics
+    %---------------------------------------------------------------
+    if pU_ST_Ut==-1 % No threshold was set in snpm_ui.
+        fprintf('\tLoading & conditioning SupraThreshold statistics...');
+        try
+            load(fullfile(CWD,'SnPM_ST'))
+        catch exception
+            if strcmp(exception.identifier, 'MATLAB:load:unableToReadMatFile')
+                warning('SnPM:SnPMSTFileNotLOaded', ...
+                    ['SnPM_ST file can not be loaded. Consider using' ...
+                    ' ''set cluster-forming threshold now (fast)'' option' ...
+                    ' in SnPM ''Specify''.']);
+            end
+            % Rethrow exception
+            throw(exception)
+        end
+        %-SnPM_ST stores columns of [x;y;z;abs(t);perm] with perm negative
+        % where the exceedence was t < -ST_Ut_0
+        %-Trim statistics according to threshold ST_Ut, if ST_Ut > ST_Ut_0
+        tmp = find(SnPM_ST(4,:)>ST_Ut);
+        SnPM_ST = SnPM_ST(:,tmp);
+        clear tmp;
+        
+        SnPM_ST_Pos = SnPM_ST(:,SnPM_ST(5,:)>0);
+        SnPM_ST_Neg = SnPM_ST(:,SnPM_ST(5,:)<0);
+        SnPM_ST_Neg(5,:) = -SnPM_ST_Neg(5,:);
+        
+        fprintf('done\n')
+        
+        %-Calculate distribution of Maximum SupraThreshold Cluster size
+        %---------------------------------------------------------------
+        fprintf('\tComputing dist. of max SupraThreshold cluster size: ');
+        STCS = snpm_STcalc('init',nPerm);
+        fprintf('\nPerms left:     ');
+        for i = nPerm:-1:1
+            if (rem(i,10)==0)
+                fprintf('\b\b\b\b%-4u',i)
+                drawnow
+            end
+            
+            if STAT== 'F'
+                loop = 1;
+            else
+                loop = 1:2;
+            end
+            
+            for isPos= loop  %1 for positive; 2 for negative
                 if isPos==1
-                    STCstats_Pos = [ SnPM_ST(:,tQ); tmp];
-                    if bNeg==0
-                        STCstats=STCstats_Pos;
-                    end
+                    SnPM_ST = SnPM_ST_Pos;
                 else
-                    STCstats_Neg = [ SnPM_ST(:,tQ); tmp];
-                    if bNeg==1
-                        STCstats=STCstats_Neg;
+                    SnPM_ST = SnPM_ST_Neg;
+                end
+                tQ = (SnPM_ST(5,:)==i);
+                if any(tQ)
+                    %-Compute cluster labellings for this perm
+                    Locs_mm = SnPM_ST(1:3,tQ);
+                    Locs_mm (4,:) = 1;
+                    Locs_vox = IMAT * Locs_mm;
+                    
+                    % Sometimes Locs_vox are not exactly integers and this raises an
+                    % error later in the code. Here check that the values are
+                    % integers with respect to a level of absolute tolerance (~10^-14)
+                    % and enforce Locs_vox to be integers.
+                    % (As in snpm_cp)
+                    diffWithRounded = max(abs(Locs_vox(:)-round(Locs_vox(:))));
+                    tolerance = 10^-10;
+                    if diffWithRounded > tolerance
+                        Locs_vox_alter = MAT\Locs_mm;
+                        diffWithRounded_alter = max(abs(Locs_vox_alter(:)-round(Locs_vox(:))));
+                        error('SnPM:NonIntegerLocsvox', ['''Locs_vox'' must be integers (difference is ' num2str(diffWithRounded) ...
+                            ' or ' num2str(diffWithRounded_alter) ')']);
+                    else
+                        Locs_vox = round(Locs_vox);
+                    end
+                    
+                    STCS = snpm_STcalc('update',STCS, SnPM_ST(4,tQ),...
+                        Locs_vox(1:3,:),isPos,i,ST_Ut,df);
+                end
+                if i==1
+                    %-Save perm 1 stats for use later - [X;Y;Z;T;perm;STCno]
+                    tmp = spm_clusters(Locs_vox(1:3,:));
+                    if isPos==1
+                        STCstats_Pos = [ SnPM_ST(:,tQ); tmp];
+                        if bNeg==0
+                            STCstats=STCstats_Pos;
+                        end
+                    else
+                        STCstats_Neg = [ SnPM_ST(:,tQ); tmp];
+                        if bNeg==1
+                            STCstats=STCstats_Neg;
+                        end
                     end
                 end
             end
         end
-    end
-	  fprintf('\b\b\b\bdone\n');
-	  
-	  if bhPerms   %Double the STCS variables.
-	    STCS = snpm_STcalc('double',STCS);
-	  end
-	  
-	  %-Get the stats from STCS structure that will be used later
-	  STCS_MxK = STCS.MxK(:,bNeg+1);
-	  STCS_K=cat(1,STCS.K{:,bNeg+1});	   
-	  
-       else % A threshold was set in snpm_ui.
-	  %-Load & condition statistics
-	  %---------------------------------------------------------------
-	  fprintf('\tLoading SupraThreshold statistics...');
-	  load(fullfile(CWD,'STCS'))
-	  STCS_MxK = STCS.MxK(:,bNeg+1);
-	  STCS_K=cat(1,STCS.K{:,bNeg+1});
-	  if (bNeg==0)
-	    load(fullfile(CWD,'SnPM_pp'))
-	  else
-	    load(fullfile(CWD,'SnPM_pp_Neg'))
-	    STCstats = STCstats_Neg;
-	  end       
-	end	
+        fprintf('\b\b\b\bdone\n');
         
-	%-Compute critical SupraThreshold Cluster size
-	if isnan(C_STCS)
-	  
-	  if ~isnan(alph_FWE)
-	    
-	    % STCS_MxK: a vector of maximum cluster sizes of all the permutations.
-	    % STCS_MxK = STCS.MxK(:,bNeg+1);  
-	    [StMaxSTCS, iStMaxSTCS] = sort(STCS_MxK);
-	    if alph_FWE < 1
-		C_STCS = StMaxSTCS(iFWE);
-	    else
-		C_STCS = 0;
-	    end
-	  
-	  elseif ~isnan(alpha_ucp)
-	    
-	    % STCS_K: a vector of all the cluster sizes of all the
+        if bhPerms   %Double the STCS variables.
+            STCS = snpm_STcalc('double',STCS);
+        end
+        
+        %-Get the stats from STCS structure that will be used later
+        STCS_MxK = STCS.MxK(:,bNeg+1);
+        STCS_K=cat(1,STCS.K{:,bNeg+1});
+        
+    else % A threshold was set in snpm_ui.
+        %-Load & condition statistics
+        %---------------------------------------------------------------
+        fprintf('\tLoading SupraThreshold statistics...');
+        load(fullfile(CWD,'STCS'))
+        STCS_MxK = STCS.MxK(:,bNeg+1);
+        STCS_K=cat(1,STCS.K{:,bNeg+1});
+        if (bNeg==0)
+            load(fullfile(CWD,'SnPM_pp'))
+        else
+            load(fullfile(CWD,'SnPM_pp_Neg'))
+            STCstats = STCstats_Neg;
+        end
+    end
+    
+    %-Compute critical SupraThreshold Cluster size
+    if isnan(C_STCS)
+        
+        if ~isnan(alph_FWE)
+            
+            % STCS_MxK: a vector of maximum cluster sizes of all the permutations.
+            % STCS_MxK = STCS.MxK(:,bNeg+1);
+            [StMaxSTCS, iStMaxSTCS] = sort(STCS_MxK);
+            if alph_FWE < 1
+                C_STCS = StMaxSTCS(iFWE);
+            else
+                C_STCS = 0;
+            end
+            
+        elseif ~isnan(alpha_ucp)
+            
+            % STCS_K: a vector of all the cluster sizes of all the
             % permutations.
-	    
-	    [StKSTCS, iStKSTCS] = sort(STCS_K);
-	    if alpha_ucp < 1
-	        iucp=ceil((1-alpha_ucp)*length(STCS_K));
-		C_STCS = StKSTCS(iucp);
-	    else
-	        C_STCS = 0;
-	    end
-	  
-	  end
-	
-	end
-	
-	%-Check XYZ for points > ST_Ut in perm 1 matches
-	% XYZ computed above for SnPMt > ST_Ut
-	%if pU_ST_Ut==-1 
-	% if ~all(all( SnPM_ST(1:3,SnPM_ST(5,:)==1) == XYZ ))
-	%	error('SnPM:InvalidSTXYZ', 'ST XYZ don''t match between STCS & thresh')
-	% end
-	%else
-	 if ~all(all( STCstats(1:3,:) == XYZ ))
-		error('SnPM:InvalidSTXYZ', 'ST XYZ don''t match between STCS & thresh')
-	 end
-	%end
+            
+            [StKSTCS, iStKSTCS] = sort(STCS_K);
+            if alpha_ucp < 1
+                iucp=ceil((1-alpha_ucp)*length(STCS_K));
+                C_STCS = StKSTCS(iucp);
+            else
+                C_STCS = 0;
+            end
+            
+        end
+        
+    end
+    
+    %-Check XYZ for points > ST_Ut in perm 1 matches
+    % XYZ computed above for SnPMt > ST_Ut
+    %if pU_ST_Ut==-1
+    % if ~all(all( SnPM_ST(1:3,SnPM_ST(5,:)==1) == XYZ ))
+    %	error('SnPM:InvalidSTXYZ', 'ST XYZ don''t match between STCS & thresh')
+    % end
+    %else
+    if ~all(all( STCstats(1:3,:) == XYZ ))
+        error('SnPM:InvalidSTXYZ', 'ST XYZ don''t match between STCS & thresh')
+    end
+    %end
 end
 
 %-Save some time consuming results
 %-----------------------------------------------------------------------
 if bSpatEx & pU_ST_Ut==-1
-  save SnPM_pp STCstats_Pos
-  if STAT == 'T'
-     save SnPM_pp_Neg STCstats_Neg
-  end
-  save STCS STCS
+    save SnPM_pp STCstats_Pos
+    if STAT == 'T'
+        save SnPM_pp_Neg STCstats_Neg
+    end
+    save STCS STCS
 end
 
 
@@ -997,47 +1089,65 @@ if bSpatEx
     % if alph_FWE is set then only do it when alph_FWE<1
     % otherwise(alph_FWE=NaN), do the analysis.
     if (alph_FWE<1|isnan(alph_FWE))
-	%-Filter on significance of cluster size
-	%---------------------------------------------------------------
-	fprintf('Filtering statistic image, clusterwise...');
-	nSTC     = max(STCstats(6,:));
-	STCS_K1  = diff(find([diff([0,sort(STCstats(6,:))]),1]));
-	Q        = [];
-	for i = 1:nSTC
-		tQ = find(STCstats(6,:)==i);
-		% Note, we discard a cluster even if it has a significant
-                % voxel in it
-		if ( STCS_K1(i) > C_STCS )
-			Q        = [Q tQ];
-		end
-	end
-	if ~isempty(Q)
-		SnPMt    = SnPMt(Q);
-		XYZ      = XYZ(:,Q);
-		STCstats = STCstats(:,Q);
-	end
-	fprintf('done\n')
+        %-Filter on significance of cluster size
+        %---------------------------------------------------------------
+        fprintf('Filtering statistic image, clusterwise...');
+        nSTC     = max(STCstats(6,:));
+        STCS_K1  = diff(find([diff([0,sort(STCstats(6,:))]),1]));
+        Q        = [];
+        for i = 1:nSTC
+            tQ = find(STCstats(6,:)==i);
+            % Note, we discard a cluster even if it has a significant
+            % voxel in it
+            if ( STCS_K1(i) > C_STCS )
+                Q        = [Q tQ];
+            end
+        end
+        if ~isempty(Q)
+            SnPMt    = SnPMt(Q);
+            XYZ      = XYZ(:,Q);
+            STCstats = STCstats(:,Q);
+        end
+        fprintf('done\n')
     end
+    
+elseif procTFCE
+    % voxel-wise inference
+    if and(~isnan(u), exist('css_vec', 'var'))
+        % Thresholding based on t-values
+        Q =  find(css_vec > u);
+        fprintf('Filtering cluster-like support score image, voxelwise...');
+    else
+        error('SnPM:CodingError', 'Coding error')
+    end
+    if ~isempty(Q)
+        SnPMt = SnPMt(Q);
+        XYZ   = XYZ(:,Q);
+    end
+    fprintf('done\n')
+    
 else
-	if ~isnan(u) 
-	  % Thresholding based on t-values
-	  Q =  find(SnPMt > u);
-	elseif ~isnan(alpha_ucp)
-	  % Thresholding based on uncorrected P-values
-	  Q = find(SnPMucp < alpha_ucp);
-	else
-	  error('SnPM:CodingError', 'Coding error')
-	end
-	if ~isnan(u)
-	  fprintf('Filtering statistic image, voxelwise...');
-	else
-	  fprintf('Filtering uncorr. p image, voxelwise...');
-	end
-	if length(Q)
-		SnPMt = SnPMt(Q);
-		XYZ   = XYZ(:,Q);
-	end
-	fprintf('done\n')
+    % voxel-wise inference
+    if ~isnan(u)
+        % Thresholding based on t-values
+        Q =  find(SnPMt > u);
+    elseif ~isnan(alpha_ucp)
+        % Thresholding based on uncorrected P-values
+        Q = find(SnPMucp < alpha_ucp);
+    else
+        error('SnPM:CodingError', 'Coding error')
+    end
+    if ~isnan(u)
+        fprintf('Filtering statistic image, voxelwise...');
+    else
+        fprintf('Filtering uncorr. p image, voxelwise...');
+    end
+    if ~isempty(Q)
+        SnPMt = SnPMt(Q);
+        XYZ   = XYZ(:,Q);
+    end
+    fprintf('done\n')
+    
 end
 
 
@@ -1045,58 +1155,64 @@ end
 %-Return if there are no voxels
 %-----------------------------------------------------------------------
 if isempty(Q)
-	set(Finter,'Pointer','Arrow')
-	figure(Fgraph)
-	axis off
-	text(0,0.97,CWD,'Fontsize',16,'FontWeight','Bold');
-	tmp='voxels'; if bSpatEx, tmp='suprathreshold clusters'; end
-	str='';
-	if ~isnan(u)
-	  if bSpatEx
-	    str=sprintf(...
-		'No %s significant at k>=%d (alpha=%6.4f FWE-corrected)\n',...
-		tmp,C_STCS,alph_FWE);
-	  else
-	    str=sprintf(...
-		'No %s significant at u>=%0.2f (alpha=%6.4f FWE-corrected)\n',...
-		tmp,u,alph_FWE);
-	  end
-	else
-	  str=sprintf(...
-	      'No %s significant at alpha=%6.4f (alpha=%6.4f FDR-corrected)\n',...
-	      tmp,alpha_ucp,alph_FDR);
-	end
-	if ~isempty(str)
-	  text(0,0.93,str);
-	  fprintf(['WARNING: ' str])
-	end
-	if length(strmatch('FWEreport',Report))>0
-	  if bSpatEx,
-	    ShowDist(MaxT,C_MaxT,alph_FWE,STCS_MxK,C_STCS,alph_FWE,'max');
-	  else	   
-	    ShowDist(MaxT,C_MaxT,alph_FWE,[],[],[],'max');
-	  end
-	  if ~BATCH
-	    if spm_input('Review permutation distributions.',1,'bd',...
-			 'Print & Continue|Continue',[1,0],1)
-	      spm_print
-	    end
-	  end
-	end
-	if length(strmatch('FDRreport',Report))>0
-	  spm_clf(Fgraph)
-	  axis off
-	  text(0,0.97,'Uncorrected P Permutation Distributions','Fontsize',16,'FontWeight',...
-	       'Bold');
-	  ShowDist(SnPMucp,alpha_ucp,alph_FDR,[],[],[],'uncor');
-	  if ~BATCH
-	    if spm_input('Review permutation distributions.',1,'bd',...
-			 'Print|Done',[1,0],1)
-	      spm_print
-	    end  
-	  end
-	end
-	return
+    set(Finter,'Pointer','Arrow')
+    figure(Fgraph)
+    axis off
+    text(0,0.97,CWD,'Fontsize',16,'FontWeight','Bold');
+    tmp='voxels'; if bSpatEx, tmp='suprathreshold clusters'; end
+    str='';
+    if ~isnan(u)
+        if bSpatEx
+            str=sprintf(...
+                'No %s significant at k>=%d (alpha=%6.4f FWE-corrected)\n',...
+                tmp,C_STCS,alph_FWE);
+        elseif procTFCE
+            str=sprintf(...
+                'No %s significant at TFCE u>=%0.2f (alpha=%6.4f FWE-corrected)\n',...
+                tmp,u,alph_FWE);
+        else
+            str=sprintf(...
+                'No %s significant at u>=%0.2f (alpha=%6.4f FWE-corrected)\n',...
+                tmp,u,alph_FWE);
+        end
+    else
+        str=sprintf(...
+            'No %s significant at alpha=%6.4f (alpha=%6.4f FDR-corrected)\n',...
+            tmp,alpha_ucp,alph_FDR);
+    end
+    if ~isempty(str)
+        text(0,0.93,str);
+        fprintf(['WARNING: ' str])
+    end
+    if ~isempty(strmatch('FWEreport',Report))
+        if bSpatEx
+            ShowDist(MaxT,C_MaxT,alph_FWE,STCS_MxK,C_STCS,alph_FWE,'max');
+        elseif procTFCE
+            ShowDist(MaxCSS,C_MaxCSS,alph_FWE,[],[],[],'max');         
+        else
+            ShowDist(MaxT,C_MaxT,alph_FWE,[],[],[],'max');
+        end
+        if ~BATCH
+            if spm_input('Review permutation distributions.',1,'bd',...
+                    'Print & Continue|Continue',[1,0],1)
+                spm_print
+            end
+        end
+    end
+    if length(strmatch('FDRreport',Report))>0
+        spm_clf(Fgraph)
+        axis off
+        text(0,0.97,'Uncorrected P Permutation Distributions','Fontsize',16,'FontWeight',...
+            'Bold');
+        ShowDist(SnPMucp,alpha_ucp,alph_FDR,[],[],[],'uncor');
+        if ~BATCH
+            if spm_input('Review permutation distributions.',1,'bd',...
+                    'Print|Done',[1,0],1)
+                spm_print
+            end
+        end
+    end
+    return
 end
 
 %-Characterize local excursions in terms of maxima:
@@ -1120,376 +1236,382 @@ STC_XYZ = TempXYZmm(1:3,:);
 %-----------------------------------------------------------------------
 Pt = ones(size(STC_r));
 for i = 1:length(STC_r)
-	%-Use a > b -tol rather than a >= b to avoid comparing reals
-	Pt(i) = sum(MaxT > STC_SnPMt(i) -tol) / nPermReal;
+    %-Use a > b -tol rather than a >= b to avoid comparing reals
+    Pt(i) = sum(MaxT > STC_SnPMt(i) -tol) / nPermReal;
 end
 
 %Since we have already considered both bNeg =0 and 1 situations in
 %ucp, the Pu has the same formula for bNeg=0 and 1.
 
-        ucp = zeros(1,prod(DIM));
-	ucp(spm_xyz2e(XYZ0,V)) = SnPMucp;
-        Pu  = ucp(spm_xyz2e(STC_XYZ,V)) ;
-        Pfdr = snpm_P_FDR(Pu,[],'P',[],sSnPMucp');
+ucp = zeros(1,prod(DIM));
+ucp(spm_xyz2e(XYZ0,V)) = SnPMucp;
+Pu  = ucp(spm_xyz2e(STC_XYZ,V)) ;
+Pfdr = snpm_P_FDR(Pu,[],'P',[],sSnPMucp');
 if bSpatEx
-	%-Compute FWE-corrected p-values and uncorrected p-values for region size: pSTSC_SS
-	Pn    = ones(size(STC_r));     % FWE-corrected p-values
-        Pun   = ones(size(STC_r));     % Uncorrected p-values
-	for i = 1:length(STC_r)
-	  Pn(i) = sum(STCS_MxK>=STC_N(i)) / nPermReal;
-          Pun(i) = sum(STCS_K>=STC_N(i)) / length(STCS_K);	  
-	end
+    %-Compute FWE-corrected p-values and uncorrected p-values for region size: pSTSC_SS
+    Pn    = ones(size(STC_r));     % FWE-corrected p-values
+    Pun   = ones(size(STC_r));     % Uncorrected p-values
+    for i = 1:length(STC_r)
+        Pn(i) = sum(STCS_MxK>=STC_N(i)) / nPermReal;
+        Pun(i) = sum(STCS_K>=STC_N(i)) / length(STCS_K);
+    end
 end
 
 % Display only if *not* in command line mode
 if ~spm_get_defaults('cmdline')
     
-%=======================================================================
-%-D I S P L A Y :   Max report
-%=======================================================================
-
-if length(strmatch('FWEreport',Report))>0
-
-  spm_clf(Fgraph)
-  figure(Fgraph)
-  axis off
-  if (bSpatEx)
-    text(0,0.97,'Permutation Distribution','Fontsize',16,'FontWeight', ...
-	 'Bold');
+    %=======================================================================
+    %-D I S P L A Y :   Max report
+    %=======================================================================
     
-    ShowDist(MaxT,C_MaxT,alph_FWE,STCS_MxK,C_STCS,alph_FWE,'max');
-  else	     
-    text(0,0.97,'Permutation Distributions','Fontsize',16,'FontWeight','Bold');
-    ShowDist(MaxT,C_MaxT,alph_FWE,[],[],[],'max');
-  end
-  
-  if ~BATCH
-    if spm_input('Review permutation distributions.',1,'bd',...
-		 'Print & Continue|Continue',[1,0],1)
-      spm_print
-    end
-  end
-end
-
-
-%=======================================================================
-%-D I S P L A Y :   FDR (uncorrected P-values) report
-%=======================================================================
-
-if length(strmatch('FDRreport',Report))>0
-
-  spm_clf(Fgraph)
-  figure(Fgraph)
-  axis off
-  text(0,0.97,'Uncorrected P Permutation Distributions','Fontsize',16,'FontWeight',...
-       'Bold');
-  ShowDist(SnPMucp,alpha_ucp,alph_FDR,[],[],[],'uncor');
-
-  if ~BATCH
-    if spm_input('Review permutation distributions.',1,'bd',...
-                  'Print & Continue|Continue',[1,0],1)
-      spm_print
-    end
-  end
-
-end
-
-
-
-%=======================================================================
-%-D I S P L A Y :   Maximium intenisty projection of SPM{Z}
-%=======================================================================
-
-if length(strmatch('MIPtable',Report))>0
-
-  spm_clf(Fgraph)
-  figure(Fgraph)
-  axis off
-  
-  hmip = axes('Position',[0.05 0.5 0.5 0.5]);
-  snpm_mip(SnPMt,XYZ,MAT,DIM); axis image
-  if bVarSm
-    title('SnPM{Pseudo-t}','FontSize',16,'Fontweight','Bold')
-  else
-    title(sprintf('SnPM{%s}',STAT),'FontSize',16,'Fontweight','Bold')
-  end
-  
-  %-Design matrix and contrast
-  %=======================================================================
-  hDesMtx = axes('Position',[0.65 0.6 0.2 0.2]);
-  image((spm_DesMtx('Sca', [H,C,B,G],HCBGnames) + 1)*32)
-  xlabel 'Design Matrix'
-  set(hDesMtx,'XTick',[],'XTickLabel','')
-  nPar   = size([H,C,B,G],2);
-  hConAxes = axes('Position',[0.65 0.81 0.2 0.1]);
-  if STAT == 'F'
-    imagesc(CONT,[-1 1]);
-    set(gca,'Tag','ConGrphAx',...
-	    'Box','on','TickDir','out',...
-	    'XTick',spm_DesRep('ScanTick',nPar,10),'XTickLabel','',...
-	    'XLim',	[0,nPar]+0.5,...
-	    'YTick',[1:size(CONT,1)],....
-	    'YTickLabel','',...
-	    'YLim',	[0,size(CONT,1)]+0.5	)
-  else
-    h = bar(CONT(1,:), 'FaceColor',[1 1 1]*.8, 'BarWidth', 1);  
-    tX = get(h,'XData'); tY = get(h,'YData');
-    bar_width = get(h, 'BarWidth');
-    set(gca,'Xlim',[min(tX(:))-bar_width/2 max(tX(:))+bar_width/2]) 
-    axis off
-  end
-  title 'contrast'; 
-  
-
-  %-Table of regional effects
-  %=======================================================================
-  %-Table headings
-  %-----------------------------------------------------------------------
-  hTable = axes('Position',[0.1 0.1 0.8 0.46],...
-		'YLim',[0,27],'YLimMode','manual',...
-		'DefaultTextInterpreter','Tex',...
-		'DefaultTextVerticalAlignment','Baseline',...
-		'Visible','off');
-  %	      'DefaultHorizontalAlignment','right',...
-  y = 26;
-  dy=1;
-  text(0,y,['P values & statistics:   ',spm_str_manip(CWD,'a40')],...
-       'FontSize',12,'FontWeight','Bold','Interpreter','none');
-  y  = y -dy;
-  line([0 1],[y y],'LineWidth',3,'Color','r')
-  y = y -dy;
-  
-  tCol       = [  0.00      0.12    0.26             ...	%-Cluster
-		  0.34      0.46    0.63      0.72   ...  %-Voxel
-		  0.88     0.94    1.00];        	%-XYZ
-  
-  PF    = spm_platform('fonts');   %-Font names (for this platform)
-
-
-  %-Construct table header
-  %-----------------------------------------------------------------------
-  set(gca,'DefaultTextFontName',PF.helvetica,'DefaultTextFontSize',10)
-  
-  Hp = [];
-  h  = text(0.10,y,	'cluster-level','FontSize',10,'HorizontalAlignment','Center');		
-  h  = line([tCol(1),0.30],[1,1]*(y-dy/4),'LineWidth',0.5,'Color','r');	
-  h  = text(tCol(1),y-9*dy/8,	'\itp_{FWE-corr}');        Hp = [Hp,h];
-  h  = text(tCol(2),y-9*dy/8,	'\itp_{uncorr}');      Hp = [Hp,h];
-  h  = text(tCol(3),y-9*dy/8,	'\itk ');			
-  
-  text(0.50,y,		'voxel-level','FontSize',10,'HorizontalAlignment','Center');
-  line([tCol(4),0.80],[1,1]*(y-dy/4),'LineWidth',0.5,'Color','r');
-  h  = text(tCol(4),y-9*dy/8,	'\itp_{FWE-corr}');	
-  h  = text(tCol(5),y-9*dy/8,	'\itp_{FDR-corr}');	
-  
-  if ~bVarSm
-    h  = text(tCol(6),y-9*dy/8,	sprintf('\\it%s',STAT));
-  else 
-    h  = text(tCol(6)-0.02,y-9*dy/8,	'Pseudo-t');
-  end 
-  
-  h  = text(tCol(7),y-9*dy/8,	'\itp_{uncorr}');
-  
-  text(tCol(8),y-dy/2,'{x,y,z} mm','FontSize',10);
-  
-  
-  y     = y - 7*dy/4;
-  line([0 1],[y y],'LineWidth',1,'Color','r')
-  y     = y - 5*dy/4;
-  
-  Fmtst = {	'%0.4f', '%0.4f', '%0.0f', ...                  %-Cluster
-		'%0.4f', '%0.4f', '%6.2f','%0.4f', ...		%-Voxel
-		'%3.0f','%3.0f','%3.0f'};			%-XYZ
-  
-  %-Column Locations
-  %-----------------------------------------------------------------------
-  %tCol       = [  0.07      0.30  ...			%-Cluster
-  %	           0.50      0.62      0.77           ...  %-Voxel
-  %                0.86 0.93 1.00];			%-XYZ
-  
-  %-List of maxima
-  %-----------------------------------------------------------------------
-  r = 1;
-  bUsed = zeros(size(STC_SnPMt));
-  while max(STC_SnPMt.*(~bUsed)) & (y > 3)
-    
-    [null, i] = max(STC_SnPMt.*(~bUsed));	% Largest t value
-    j         = find(STC_r == STC_r(i));	% Maxima in same region
-    
-    %-Print region and largest maximum
-    %-------------------------------------------------------------------
-    
-    StrAttr = {'Fontsize',10,'ButtonDownFcn','get(gcbo, ''UserData'')',...
-	       'HorizontalAlignment','right'};
-    StrAttrB = {StrAttr{:},'FontWeight','Bold'};
-    %	text(0.00,y,sprintf('%0.0f',r),'UserData',r,StrAttrB{:})
-    if bSpatEx
-      text(tCol(1)+0.09,y,sprintf(Fmtst{1},Pn(i)),'UserData',Pn(i), ...
-	   StrAttrB{:})
-      text(tCol(2)+0.09,y,sprintf(Fmtst{2},Pun(i)),'UserData',Pun(i), ...
-	   StrAttrB{:})
-    else
-      set(Hp,'Visible','off')
+    if length(strmatch('FWEreport',Report))>0
+        
+        spm_clf(Fgraph)
+        figure(Fgraph)
+        axis off
+        text(0,0.97,'Permutation Distribution','Fontsize',16,'FontWeight', 'Bold');
+        if bSpatEx
+            ShowDist(MaxT,C_MaxT,alph_FWE,STCS_MxK,C_STCS,alph_FWE,'max');
+        elseif procTFCE
+            ShowDist(MaxCSS,C_MaxCSS,alph_FWE,[],[],[],'max');         
+        else
+            ShowDist(MaxT,C_MaxT,alph_FWE,[],[],[],'max');
+        end        
+        if ~BATCH
+            if spm_input('Review permutation distributions.',1,'bd',...
+                    'Print & Continue|Continue',[1,0],1)
+                spm_print
+            end
+        end
     end
     
-    text(tCol(3)+0.04,y,sprintf(Fmtst{3},STC_N(i)),'UserData',STC_N(i),StrAttrB{:})
-    text(tCol(4)+0.08,y,sprintf(Fmtst{4},Pt(i)),'UserData',Pt(i),StrAttrB{:})
-    text(tCol(5)+0.09,y,sprintf(Fmtst{5},Pfdr(i)),'UserData',Pfdr(i),StrAttrB{:})
-    text(tCol(6)+0.04,y,sprintf(Fmtst{6},STC_SnPMt(i)),'UserData',STC_SnPMt(i),StrAttrB{:})
     
-    text(tCol(7)+0.09,y,sprintf(Fmtst{7},Pu(i)),'UserData',Pu(i),StrAttr{:})
-    text(tCol(8),y,sprintf(Fmtst{8},STC_XYZ(1,i)),'UserData',STC_XYZ(:,i),StrAttrB{:})
-    text(tCol(9),y,sprintf(Fmtst{9},STC_XYZ(2,i)),'UserData',STC_XYZ(:,i),StrAttrB{:})
-    text(tCol(10),y,sprintf(Fmtst{10},STC_XYZ(3,i)),'UserData',STC_XYZ(:,i),StrAttrB{:})
-    y = y -1;
+    %=======================================================================
+    %-D I S P L A Y :   FDR (uncorrected P-values) report
+    %=======================================================================
     
-    %-Print up to 3 secondary maxima (>8mm apart)
-    %-------------------------------------------------------------------
-    [null, k] = sort(-STC_SnPMt(j));	% Sort on t value
-    D         = i;
-    for i = 1:length(k)
-      d     = j(k(i));
-      if min( sqrt( sum((STC_XYZ(:,D) - ...
-			 STC_XYZ(:,d)*ones(1,size(D,2))).^2) ) ) > 8;
-	if length(D) < 3
-	  text(tCol(4)+0.08,y,sprintf(Fmtst{4}, Pt(d)),'UserData',Pt(d),StrAttr{:})
-	  text(tCol(5)+0.09,y,sprintf(Fmtst{5}, Pfdr(d)),'UserData',Pfdr(d),StrAttr{:})
-	  text(tCol(6)+0.04,y,sprintf(Fmtst{6}, STC_SnPMt(d)), 'UserData',STC_SnPMt(d),StrAttr{:})
-	  
-	  text(tCol(7)+0.09,y,sprintf(Fmtst{7}, Pu(d)),'UserData',Pu(d),StrAttr{:})
-	  text(tCol(8),y,sprintf(Fmtst{8}, STC_XYZ(1,d)),'UserData',STC_XYZ(:,d),StrAttr{:})
-	  text(tCol(9),y,sprintf(Fmtst{9}, STC_XYZ(2,d)),'UserData',STC_XYZ(:,d),StrAttr{:})
-	  text(tCol(10),y,sprintf(Fmtst{10}, STC_XYZ(3,d)),'UserData',STC_XYZ(:,d),StrAttr{:})
-	  
-	  D = [D d];
-	  y = y -1;
-	end
-      end
+    if length(strmatch('FDRreport',Report))>0
+        
+        spm_clf(Fgraph)
+        figure(Fgraph)
+        axis off
+        text(0,0.97,'Uncorrected P Permutation Distributions','Fontsize',16,'FontWeight',...
+            'Bold');
+        ShowDist(SnPMucp,alpha_ucp,alph_FDR,[],[],[],'uncor');
+        
+        if ~BATCH
+            if spm_input('Review permutation distributions.',1,'bd',...
+                    'Print & Continue|Continue',[1,0],1)
+                spm_print
+            end
+        end
+        
     end
     
-    bUsed(j) = (bUsed(j) | 1 );		%-Mark maxima as "used"
-    r = r + 1;				% Next region
-  end
-  clear i j k D d r
-  
-  
-  %-Footnote with SnPM parameters
-  %=======================================================================
-  line([0,1],[0.5,0.5],'LineWidth',1,'Color','r')
-  y = 0;
-  if bSpatEx
-    tmp = sprintf('Cluster-defining thresh. = %7.4f',ST_Ut);
-    if ~bVarSm
-      tmp=[tmp,sprintf(' (p = %6.4f)',spm_Tcdf(-ST_Ut,df))];
-    end
-    text(0,y,tmp,'FontSize',8)
-    text(0.7,y,sprintf('Critical STCS = %d voxels',C_STCS),'FontSize',8)
-    y = y -0.8;
-    if ~isnan(alph_FWE)
-      tmp = sprintf('Cluster threshold: FWE-corr. P value= %6.4f', ...
-		    alph_FWE);
-    elseif ~isnan(alpha_ucp)
-      tmp = sprintf('Cluster threshold: Uncorr. P value= %6.4f', ...
-		    alpha_ucp);
-    else
-      tmp = sprintf('Cluster threshold: Uncorr. cluster size STCS= %d', ...
-		    C_STCS);
-    end
-    text(0,y,tmp, 'FontSize',8)
-  else
-    %make the format similar as spm.
-    %text(0,y,sprintf('alpha = %6.4f, df = %d',alpha,df),'FontSize',8)
-    if ~isnan(u)
-      text(0,y,sprintf('Height threshold: statistic u= %6.2f (%0.4f FWE)',u,alph_FWE),'FontSize',8)
-    else
-      text(0,y,sprintf('Height threshold: Nonparam. P value alpha= %0.4f (%0.4f FDR)',alpha_ucp, alph_FDR), 'FontSize',8)   
+    
+    
+    %=======================================================================
+    %-D I S P L A Y :   Maximium intenisty projection of SPM{Z}
+    %=======================================================================
+    
+    if length(strmatch('MIPtable',Report))>0
+        
+        spm_clf(Fgraph)
+        figure(Fgraph)
+        axis off
+        
+        hmip = axes('Position',[0.05 0.5 0.5 0.5]);
+        snpm_mip(SnPMt,XYZ,MAT,DIM); axis image
+        if bVarSm
+            title('SnPM{Pseudo-t}','FontSize',16,'Fontweight','Bold')
+        else
+            title(sprintf('SnPM{%s}',STAT),'FontSize',16,'Fontweight','Bold')
+        end
+        
+        %-Design matrix and contrast
+        %=======================================================================
+        hDesMtx = axes('Position',[0.65 0.6 0.2 0.2]);
+        image((spm_DesMtx('Sca', [H,C,B,G],HCBGnames) + 1)*32)
+        xlabel 'Design Matrix'
+        set(hDesMtx,'XTick',[],'XTickLabel','')
+        nPar   = size([H,C,B,G],2);
+        hConAxes = axes('Position',[0.65 0.81 0.2 0.1]);
+        if STAT == 'F'
+            imagesc(CONT,[-1 1]);
+            set(gca,'Tag','ConGrphAx',...
+                'Box','on','TickDir','out',...
+                'XTick',spm_DesRep('ScanTick',nPar,10),'XTickLabel','',...
+                'XLim',	[0,nPar]+0.5,...
+                'YTick',[1:size(CONT,1)],....
+                'YTickLabel','',...
+                'YLim',	[0,size(CONT,1)]+0.5	)
+        else
+            h = bar(CONT(1,:), 'FaceColor',[1 1 1]*.8, 'BarWidth', 1);
+            tX = get(h,'XData'); tY = get(h,'YData');
+            bar_width = get(h, 'BarWidth');
+            set(gca,'Xlim',[min(tX(:))-bar_width/2 max(tX(:))+bar_width/2])
+            axis off
+        end
+        title 'contrast';
+        
+        
+        %-Table of regional effects
+        %=======================================================================
+        %-Table headings
+        %-----------------------------------------------------------------------
+        hTable = axes('Position',[0.1 0.1 0.8 0.46],...
+            'YLim',[0,27],'YLimMode','manual',...
+            'DefaultTextInterpreter','Tex',...
+            'DefaultTextVerticalAlignment','Baseline',...
+            'Visible','off');
+        %	      'DefaultHorizontalAlignment','right',...
+        y = 26;
+        dy=1;
+        text(0,y,['P values & statistics:   ',spm_str_manip(CWD,'a40')],...
+            'FontSize',12,'FontWeight','Bold','Interpreter','none');
+        y  = y -dy;
+        line([0 1],[y y],'LineWidth',3,'Color','r')
+        y = y -dy;
+        
+        tCol       = [  0.00      0.12    0.26             ...	%-Cluster
+            0.34      0.46    0.63      0.72   ...  %-Voxel
+            0.88     0.94    1.00];        	%-XYZ
+        
+        PF    = spm_platform('fonts');   %-Font names (for this platform)
+        
+        
+        %-Construct table header
+        %-----------------------------------------------------------------------
+        set(gca,'DefaultTextFontName',PF.helvetica,'DefaultTextFontSize',10)
+        
+        Hp = [];
+        h  = text(0.10,y,	'cluster-level','FontSize',10,'HorizontalAlignment','Center');
+        h  = line([tCol(1),0.30],[1,1]*(y-dy/4),'LineWidth',0.5,'Color','r');
+        h  = text(tCol(1),y-9*dy/8,	'\itp_{FWE-corr}');        Hp = [Hp,h];
+        h  = text(tCol(2),y-9*dy/8,	'\itp_{uncorr}');      Hp = [Hp,h];
+        h  = text(tCol(3),y-9*dy/8,	'\itk ');
+        
+        text(0.50,y,		'voxel-level','FontSize',10,'HorizontalAlignment','Center');
+        line([tCol(4),0.80],[1,1]*(y-dy/4),'LineWidth',0.5,'Color','r');
+        h  = text(tCol(4),y-9*dy/8,	'\itp_{FWE-corr}');
+        h  = text(tCol(5),y-9*dy/8,	'\itp_{FDR-corr}');
+        
+        if ~bVarSm
+            h  = text(tCol(6),y-9*dy/8,	sprintf('\\it%s',STAT));
+        else
+            h  = text(tCol(6)-0.02,y-9*dy/8,	'Pseudo-t');
+        end
+        
+        h  = text(tCol(7),y-9*dy/8,	'\itp_{uncorr}');
+        
+        text(tCol(8),y-dy/2,'{x,y,z} mm','FontSize',10);
+        
+        
+        y     = y - 7*dy/4;
+        line([0 1],[y y],'LineWidth',1,'Color','r')
+        y     = y - 5*dy/4;
+        
+        Fmtst = {	'%0.4f', '%0.4f', '%0.0f', ...                  %-Cluster
+            '%0.4f', '%0.4f', '%6.2f','%0.4f', ...		%-Voxel
+            '%3.0f','%3.0f','%3.0f'};			%-XYZ
+        
+        %-Column Locations
+        %-----------------------------------------------------------------------
+        %tCol       = [  0.07      0.30  ...			%-Cluster
+        %	           0.50      0.62      0.77           ...  %-Voxel
+        %                0.86 0.93 1.00];			%-XYZ
+        
+        %-List of maxima
+        %-----------------------------------------------------------------------
+        r = 1;
+        bUsed = zeros(size(STC_SnPMt));
+        while max(STC_SnPMt.*(~bUsed)) & (y > 3)
+            
+            [null, i] = max(STC_SnPMt.*(~bUsed));	% Largest t value
+            j         = find(STC_r == STC_r(i));	% Maxima in same region
+            
+            %-Print region and largest maximum
+            %-------------------------------------------------------------------
+            
+            StrAttr = {'Fontsize',10,'ButtonDownFcn','get(gcbo, ''UserData'')',...
+                'HorizontalAlignment','right'};
+            StrAttrB = {StrAttr{:},'FontWeight','Bold'};
+            %	text(0.00,y,sprintf('%0.0f',r),'UserData',r,StrAttrB{:})
+            if bSpatEx
+                text(tCol(1)+0.09,y,sprintf(Fmtst{1},Pn(i)),'UserData',Pn(i), ...
+                    StrAttrB{:})
+                text(tCol(2)+0.09,y,sprintf(Fmtst{2},Pun(i)),'UserData',Pun(i), ...
+                    StrAttrB{:})
+            else
+                set(Hp,'Visible','off')
+            end
+            
+            text(tCol(3)+0.04,y,sprintf(Fmtst{3},STC_N(i)),'UserData',STC_N(i),StrAttrB{:})
+            text(tCol(4)+0.08,y,sprintf(Fmtst{4},Pt(i)),'UserData',Pt(i),StrAttrB{:})
+            text(tCol(5)+0.09,y,sprintf(Fmtst{5},Pfdr(i)),'UserData',Pfdr(i),StrAttrB{:})
+            text(tCol(6)+0.04,y,sprintf(Fmtst{6},STC_SnPMt(i)),'UserData',STC_SnPMt(i),StrAttrB{:})
+            
+            text(tCol(7)+0.09,y,sprintf(Fmtst{7},Pu(i)),'UserData',Pu(i),StrAttr{:})
+            text(tCol(8),y,sprintf(Fmtst{8},STC_XYZ(1,i)),'UserData',STC_XYZ(:,i),StrAttrB{:})
+            text(tCol(9),y,sprintf(Fmtst{9},STC_XYZ(2,i)),'UserData',STC_XYZ(:,i),StrAttrB{:})
+            text(tCol(10),y,sprintf(Fmtst{10},STC_XYZ(3,i)),'UserData',STC_XYZ(:,i),StrAttrB{:})
+            y = y -1;
+            
+            %-Print up to 3 secondary maxima (>8mm apart)
+            %-------------------------------------------------------------------
+            [null, k] = sort(-STC_SnPMt(j));	% Sort on t value
+            D         = i;
+            for i = 1:length(k)
+                d     = j(k(i));
+                if min( sqrt( sum((STC_XYZ(:,D) - ...
+                        STC_XYZ(:,d)*ones(1,size(D,2))).^2) ) ) > 8;
+                    if length(D) < 3
+                        text(tCol(4)+0.08,y,sprintf(Fmtst{4}, Pt(d)),'UserData',Pt(d),StrAttr{:})
+                        text(tCol(5)+0.09,y,sprintf(Fmtst{5}, Pfdr(d)),'UserData',Pfdr(d),StrAttr{:})
+                        text(tCol(6)+0.04,y,sprintf(Fmtst{6}, STC_SnPMt(d)), 'UserData',STC_SnPMt(d),StrAttr{:})
+                        
+                        text(tCol(7)+0.09,y,sprintf(Fmtst{7}, Pu(d)),'UserData',Pu(d),StrAttr{:})
+                        text(tCol(8),y,sprintf(Fmtst{8}, STC_XYZ(1,d)),'UserData',STC_XYZ(:,d),StrAttr{:})
+                        text(tCol(9),y,sprintf(Fmtst{9}, STC_XYZ(2,d)),'UserData',STC_XYZ(:,d),StrAttr{:})
+                        text(tCol(10),y,sprintf(Fmtst{10}, STC_XYZ(3,d)),'UserData',STC_XYZ(:,d),StrAttr{:})
+                        
+                        D = [D d];
+                        y = y -1;
+                    end
+                end
+            end
+            
+            bUsed(j) = (bUsed(j) | 1 );		%-Mark maxima as "used"
+            r = r + 1;				% Next region
+        end
+        clear i j k D d r
+        
+        
+        %-Footnote with SnPM parameters
+        %=======================================================================
+        line([0,1],[0.5,0.5],'LineWidth',1,'Color','r')
+        y = 0;
+        if bSpatEx
+            tmp = sprintf('Cluster-defining thresh. = %7.4f',ST_Ut);
+            if ~bVarSm
+                tmp=[tmp,sprintf(' (p = %6.4f)',spm_Tcdf(-ST_Ut,df))];
+            end
+            text(0,y,tmp,'FontSize',8)
+            text(0.7,y,sprintf('Critical STCS = %d voxels',C_STCS),'FontSize',8)
+            y = y -0.8;
+            if ~isnan(alph_FWE)
+                tmp = sprintf('Cluster threshold: FWE-corr. P value= %6.4f', ...
+                    alph_FWE);
+            elseif ~isnan(alpha_ucp)
+                tmp = sprintf('Cluster threshold: Uncorr. P value= %6.4f', ...
+                    alpha_ucp);
+            else
+                tmp = sprintf('Cluster threshold: Uncorr. cluster size STCS= %d', ...
+                    C_STCS);
+            end
+            text(0,y,tmp, 'FontSize',8)
+            
+        elseif procTFCE
+            if ~isnan(u)
+                text(0,y,sprintf('Height threshold: TFCE statistic u= %6.2f (%0.4f FWE)',u,alph_FWE),'FontSize',8)
+            else
+                error('SnPM:CodingError', 'Coding error')
+            end
+            
+        else
+            %make the format similar as spm.
+            %text(0,y,sprintf('alpha = %6.4f, df = %d',alpha,df),'FontSize',8)
+            if ~isnan(u)
+                text(0,y,sprintf('Height threshold: statistic u= %6.2f (%0.4f FWE)',u,alph_FWE),'FontSize',8)
+            else
+                text(0,y,sprintf('Height threshold: Nonparam. P value alpha= %0.4f (%0.4f FDR)',alpha_ucp, alph_FDR), 'FontSize',8)
+            end
+            
+        end
+        
+        if bVarSm
+            str = 'n/a (variance smoothing)';
+        else
+            str = sprintf('[%d %d]',df1,df);
+        end
+        text(0.7,y,['Degrees of freedom = ', str], 'FontSize',8)
+        y=y-0.8;
+        text(0,y,sprintf('Design: %s',sDesign),'FontSize',8);
+        y=y-0.8;
+        text(0,y,sprintf('Search vol: %d cmm, %d voxels',S*abs(prod(VOX)),S), 'FontSize',8)
+        y=y-0.8;
+        text(0.7,y,sprintf('Voxel size: [%5.2f, %5.2f, %5.2f] mm',abs(VOX)), ...
+            'FontSize', 8)
+        
+        text(0,y,sprintf('Perms: %s',sPiCond),'FontSize',8);
+        if bVarSm
+            y = y -0.8;
+            text(0,y,sVarSm,'FontSize',8)
+        end
+        
+        
+        if ~BATCH
+            %Set a button, so the user can decide whether to print the page of
+            %results to spm2.ps.
+            if spm_input('Review results.',1,'bd','Print|Done',[1,0],1)
+                spm_print
+            end
+        end
+        
+        set(Finter,'Pointer','Arrow')
+        
     end
     
-  end
-  
-  if bVarSm
-    str = 'n/a (variance smoothing)';
-  else
-    str = sprintf('[%d %d]',df1,df);
-  end
-  text(0.7,y,['Degrees of freedom = ', str], 'FontSize',8)
-  y=y-0.8;
-  text(0,y,sprintf('Design: %s',sDesign),'FontSize',8);
-  y=y-0.8;
-  text(0,y,sprintf('Search vol: %d cmm, %d voxels',S*abs(prod(VOX)),S), 'FontSize',8)
-  y=y-0.8;
-  text(0.7,y,sprintf('Voxel size: [%5.2f, %5.2f, %5.2f] mm',abs(VOX)), ...
-       'FontSize', 8)
-  
-  text(0,y,sprintf('Perms: %s',sPiCond),'FontSize',8);
-  if bVarSm
-    y = y -0.8;
-    text(0,y,sVarSm,'FontSize',8)
-  end
-  
-
-  if ~BATCH
-    %Set a button, so the user can decide whether to print the page of
-    %results to spm2.ps.
-    if spm_input('Review results.',1,'bd','Print|Done',[1,0],1)
-      spm_print
-    end 
-  end
-  
-  set(Finter,'Pointer','Arrow')
-
-end
-
 end
 
 %- Image output?
 %=======================================================================
 %-Write out filtered SnPMt?
 if WrtFlt
-	
-  Fname = WrtFltFn;
-  
-  %-Set name string
-  %---------------------------------------------------------------
-  if ~bVarSm
-    tmp = sprintf('SPMt - %d df',df);
-  else
-    tmp = 'SnPMt - pseudo t';
-  end
-  
-  %-Reconstruct filtered image from XYZ & SnPMt
-  %---------------------------------------------------------------
-  t = zeros(1,prod(DIM))*NaN;
-  t(spm_xyz2e(XYZ,V)) = SnPMt;
-  if ~bSpatEx
-    if ~isnan(u)
-      tmp=sprintf('%s p<%10g FWE-corr @ voxel level',tmp,alph_FWE);
+    
+    Fname = WrtFltFn;
+    
+    %-Set name string
+    %---------------------------------------------------------------
+    if ~bVarSm
+        tmp = sprintf('SPMt - %d df',df);
     else
-      tmp=sprintf('%s p<%10g uncorr @ voxel level',tmp,alpha_ucp);
+        tmp = 'SnPMt - pseudo t';
     end
-  else
-    if ~isnan(alph_FWE)
-      tmp=sprintf('%s p<%10g corrected @ cluster level, u=%4.2f',...
-		  tmp,alph_FWE,ST_Ut);
-    elseif ~isnan(alpha_ucp)
-      tmp=sprintf('%s p<%10g uncorrected @ cluster level, u=%4.2f',...
-		  tmp,alpha_ucp,ST_Ut);
+    
+    %-Reconstruct filtered image from XYZ & SnPMt
+    %---------------------------------------------------------------
+    t = zeros(1,prod(DIM))*NaN;
+    t(spm_xyz2e(XYZ,V)) = SnPMt;
+    if ~bSpatEx
+        if ~isnan(u)
+            tmp=sprintf('%s p<%10g FWE-corr @ voxel level',tmp,alph_FWE);
+        else
+            tmp=sprintf('%s p<%10g uncorr @ voxel level',tmp,alpha_ucp);
+        end
     else
-      tmp=sprintf('%s cluster size >%d @ cluster level, u=%4.2f',...
-		  tmp,C_STCS,ST_Ut);
-    end    
-  end
-  
-  %-Write out to image file
-  %---------------------------------------------------------------
-  Vs = snpm_clone_vol(Vs0, Fname, tmp); 
-  Vs =  spm_create_vol(Vs);
-  t = reshape(t,DIM);
-  for p=1:Vs.dim(3)
-    Vs = spm_write_plane(Vs,t(:,:,p),p);
-  end
-  Vs =  sf_close_vol(Vs);
-  clear t
+        if ~isnan(alph_FWE)
+            tmp=sprintf('%s p<%10g corrected @ cluster level, u=%4.2f',...
+                tmp,alph_FWE,ST_Ut);
+        elseif ~isnan(alpha_ucp)
+            tmp=sprintf('%s p<%10g uncorrected @ cluster level, u=%4.2f',...
+                tmp,alpha_ucp,ST_Ut);
+        else
+            tmp=sprintf('%s cluster size >%d @ cluster level, u=%4.2f',...
+                tmp,C_STCS,ST_Ut);
+        end
+    end
+    
+    %-Write out to image file
+    %---------------------------------------------------------------
+    Vs = snpm_clone_vol(Vs0, Fname, tmp);
+    Vs =  spm_create_vol(Vs);
+    t = reshape(t,DIM);
+    for p=1:Vs.dim(3)
+        Vs = spm_write_plane(Vs,t(:,:,p),p);
+    end
+    Vs =  sf_close_vol(Vs);
+    clear t
 end
 
 %-Reset Interactive Window
@@ -1509,7 +1631,7 @@ function ShowDist(T,cT,aT,C,cC,aC,Typ)
 % cC   - Cluster size statistic threshold
 % aC   - (FWE) size of cC
 % Typ  - 'uncor' for uncorrected values or 'max' for corrected
-% 
+%
 % Display permutation distributions on current figure, using position
 % pos.
 %
@@ -1525,12 +1647,12 @@ if nargin<7, Typ ='max'; end
 figure(spm_figure('FindWin','Graphics'));
 
 if strcmp(Typ,'max')
-  TitStr = 'Permutation Distribution:  Maximum Statistic';
+    TitStr = 'Permutation Distribution:  Maximum Statistic';
 elseif  strcmp(Typ,'uncor')
-  TitStr = 'Distribution: Observed Uncorrected P-values';
+    TitStr = 'Distribution: Observed Uncorrected P-values';
 else
-  error('SnPM:UnknownString', 'Unknown type string')
-end  
+    error('SnPM:UnknownString', 'Unknown type string')
+end
 
 pos1 = [0.125 0.50 0.75 0.3];
 pos2 = [0.125 0.08 0.75 0.3];
@@ -1541,94 +1663,94 @@ pos2 = [0.125 0.08 0.75 0.3];
 % Bin width rule from Scott, "Multivariate Density Estimation", 1992, pg 55.
 %
 axes('position',pos1)
-BinWd  = 3.5*std(T)*length(T)^(-1/3);  
+BinWd  = 3.5*std(T)*length(T)^(-1/3);
 nBin   = floor((max(T)-min(T))/BinWd)+1;
 nBin   = min(max(nBin,10),50);
 
 hist(T,nBin);
-set(get(gca,'Children'),'FaceColor',[.5 .5 .5]) 
+set(get(gca,'Children'),'FaceColor',[.5 .5 .5])
 title([ TitStr],'FontSize',14)
 Ylim = get(gca,'ylim'); Xlim = get(gca,'xlim');
 if strcmp(Typ,'max')
-  str = sprintf('Observed Maximum Statistic = %g   ',T(1));
-  if ~isnan(cT)
-    str = {str, ...
-	   sprintf('Voxelwise statistic threshold = %g (%0.4f FWE)',cT,aT)};
-    text(cT+diff(Xlim)*0.01,Ylim(2)*0.85,'Threshold','FontSize',10);
-  end
-  xlabel(str)
-  line(T(1)*[1 1],Ylim.*[1 0.95],'LineStyle','--','color',[1 0 0]);
-  text(T(1)+diff(Xlim)*0.01,Ylim(2)*0.95,'Observed','FontSize',10)
-  if (Xlim(1)<=cT) & (cT<=Xlim(2))
-  line(cT*[1 1],Ylim.*[1 0.85],'LineStyle','-');
-  end
+    str = sprintf('Observed Maximum Statistic = %g   ',T(1));
+    if ~isnan(cT)
+        str = {str, ...
+            sprintf('Voxelwise statistic threshold = %g (%0.4f FWE)',cT,aT)};
+        text(cT+diff(Xlim)*0.01,Ylim(2)*0.85,'Threshold','FontSize',10);
+    end
+    xlabel(str)
+    line(T(1)*[1 1],Ylim.*[1 0.95],'LineStyle','--','color',[1 0 0]);
+    text(T(1)+diff(Xlim)*0.01,Ylim(2)*0.95,'Observed','FontSize',10)
+    if (Xlim(1)<=cT) & (cT<=Xlim(2))
+        line(cT*[1 1],Ylim.*[1 0.85],'LineStyle','-');
+    end
 else
-  str = sprintf('Smallest Observed Uncorr. P-value = %g    ',min(T));
-  if ~isnan(cT)
-    str = {str, ...
-	   sprintf('Voxelwise P-value threshold = %g (%0.4f FDR)',cT,aT)};
-    text(cT+diff(Xlim)*0.01,Ylim(2)*0.85,...
-	 sprintf('Threshold (%g)',cT),'FontSize',10);
-  end
-  xlabel(str);
-  snpm_abline('h',length(T)/nBin);
+    str = sprintf('Smallest Observed Uncorr. P-value = %g    ',min(T));
+    if ~isnan(cT)
+        str = {str, ...
+            sprintf('Voxelwise P-value threshold = %g (%0.4f FDR)',cT,aT)};
+        text(cT+diff(Xlim)*0.01,Ylim(2)*0.85,...
+            sprintf('Threshold (%g)',cT),'FontSize',10);
+    end
+    xlabel(str);
+    snpm_abline('h',length(T)/nBin);
 end
 
 
 if strcmp(Typ,'uncor')
-
-  %
-  % Show FDR plot
-  %
-
-  S = length(T);
-  Ts = sort(T);
-  figure(spm_figure('FindWin','Graphics'));
-  axes('position',pos2)
-  loglog((1:S)/S,Ts,'r-o')
-  set(get(gca,'children'),'LineWidth',1,'MarkerSize',2)
-  snpm_abline(0,1);
-  snpm_abline(0,aT,'LineStyle','-','color','red')
-  if ~isnan(cT) & (cT~=0)
-    snpm_abline('h',cT,'LineStyle','-','Color','blue');
-    text(10^(log10(1/S)*0.9),10^(log10(cT)*.85),...
-	 sprintf('%3.3g FDR: p=%g',aT,cT),'color','red','FontSize',10)
-  end
-  title('FDR illustration: loglog pp-plot','FontSize',20)
-  axis image
-  xlabel('index/(number of voxels)'); 
-  ylabel('Ordered uncorrected nonparametric p-value')
-
-
+    
+    %
+    % Show FDR plot
+    %
+    
+    S = length(T);
+    Ts = sort(T);
+    figure(spm_figure('FindWin','Graphics'));
+    axes('position',pos2)
+    loglog((1:S)/S,Ts,'r-o')
+    set(get(gca,'children'),'LineWidth',1,'MarkerSize',2)
+    snpm_abline(0,1);
+    snpm_abline(0,aT,'LineStyle','-','color','red')
+    if ~isnan(cT) & (cT~=0)
+        snpm_abline('h',cT,'LineStyle','-','Color','blue');
+        text(10^(log10(1/S)*0.9),10^(log10(cT)*.85),...
+            sprintf('%3.3g FDR: p=%g',aT,cT),'color','red','FontSize',10)
+    end
+    title('FDR illustration: loglog pp-plot','FontSize',20)
+    axis image
+    xlabel('index/(number of voxels)');
+    ylabel('Ordered uncorrected nonparametric p-value')
+    
+    
 elseif ~isempty(C)
-
-  %
-  % Display cluster size perm dist
-  %
-
-  axes('position',pos2)
-  rC = C.^(1/3);
-  BinWd  = 3.5*std(rC)*length(rC)^(-1/3);
-  nBin   = floor((max(rC)-min(rC))/BinWd)+1;
-  nBin   = min(max(nBin,10),50);
-
-  hist(rC,nBin);
-  set(get(gca,'Children'),'FaceColor',[.5 .5 .5]) 
-  if strcmp(Typ,'max')
-    title('Permutation Distribution: Maximum Cluster Size (cuberoot plot)','FontSize',14)
-    xlabel(sprintf('Max Cluster Size Observed = %g  Cluster Threshold = %g',C(1),cC))
-  else
-    warning('SnPM:UncorrectedClustSize', 'Uncorrected cluster size not supported yet!')
-    title('Permutation Distribution: (Uncorrected) Cuberoot Cluster Size','FontSize',14)
-    xlabel(sprintf('Max Cluster Size Observed = %g  Cluster Threshold = %g',C(1),cC))
-  end
-  Ylim = get(gca,'ylim'); Xlim = get(gca,'xlim');
-  set(gca,'Xticklabel',num2str(str2double(cellstr(get(gca,'Xticklabel'))).^3))
-  line(rC(1)*[1 1],Ylim.*[1 0.95],'LineStyle','--','color',[1 0 0]);
-  text(rC(1)+diff(Xlim)*0.01,Ylim(2)*0.95,'Observed','FontSize',10)
-  line(cC.^(1/3)*[1 1],Ylim.*[1 0.85],'LineStyle','-');
-  text(cC.^(1/3)+diff(Xlim)*0.01,Ylim(2)*0.85,'Threshold','FontSize',10)
-
+    
+    %
+    % Display cluster size perm dist
+    %
+    
+    axes('position',pos2)
+    rC = C.^(1/3);
+    BinWd  = 3.5*std(rC)*length(rC)^(-1/3);
+    nBin   = floor((max(rC)-min(rC))/BinWd)+1;
+    nBin   = min(max(nBin,10),50);
+    
+    hist(rC,nBin);
+    set(get(gca,'Children'),'FaceColor',[.5 .5 .5])
+    if strcmp(Typ,'max')
+        title('Permutation Distribution: Maximum Cluster Size (cuberoot plot)','FontSize',14)
+        xlabel(sprintf('Max Cluster Size Observed = %g  Cluster Threshold = %g',C(1),cC))
+    else
+        warning('SnPM:UncorrectedClustSize', 'Uncorrected cluster size not supported yet!')
+        title('Permutation Distribution: (Uncorrected) Cuberoot Cluster Size','FontSize',14)
+        xlabel(sprintf('Max Cluster Size Observed = %g  Cluster Threshold = %g',C(1),cC))
+    end
+    Ylim = get(gca,'ylim'); Xlim = get(gca,'xlim');
+    set(gca,'Xticklabel',num2str(str2double(cellstr(get(gca,'Xticklabel'))).^3))
+    line(rC(1)*[1 1],Ylim.*[1 0.95],'LineStyle','--','color',[1 0 0]);
+    text(rC(1)+diff(Xlim)*0.01,Ylim(2)*0.95,'Observed','FontSize',10)
+    line(cC.^(1/3)*[1 1],Ylim.*[1 0.85],'LineStyle','-');
+    text(cC.^(1/3)+diff(Xlim)*0.01,Ylim(2)*0.85,'Threshold','FontSize',10)
+    
 end
 
 return
@@ -1637,18 +1759,18 @@ return
 
 function Vs = sf_close_vol(Vs)
 switch spm('ver')
- case 'SPM99'
-  % n/a; File closed by spm_write_plane
- case 'SPM2'
-  % Vs = spm_close_vol(Vs);
-  % Don't need to close images in SPM5??
-end         
+    case 'SPM99'
+        % n/a; File closed by spm_write_plane
+    case 'SPM2'
+        % Vs = spm_close_vol(Vs);
+        % Don't need to close images in SPM5??
+end
 return
 
 function v = BoundCheck(val,Range,ErrMsg)
 if val<Range(1) | val>Range(2)
-  error('SnPM:RangeError', [ErrMsg ': ' num2str(val)])
+    error('SnPM:RangeError', [ErrMsg ': ' num2str(val)])
 else
-  v=val;
+    v=val;
 end
 return

--- a/snpm_tfce.m
+++ b/snpm_tfce.m
@@ -1,0 +1,59 @@
+function [tfced] = snpm_tfce(img,H,E,C,dh)
+% Threshold-Free Cluster Enhancement as per Smith & Nichols (2009).
+% FORMAT [tfced] = snpm_tfce(img,H,E,C,dh);
+% img   - the 3D image to be transformed
+% H     - height exponent, default = 2
+% E     - extent exponent, default = 0.5
+% C     - connectivity, default 18 (6 = surface, 18 = edge, 26 = corner)
+% df    - size of steps for cluster formation, default = 0.1
+%
+%   More steps will be more precise but will require more time and memory.
+%   The H & E default parameter settings match FSL's randomise/fslmaths.
+%   The C default setting matches SPM's default cluster forming. 
+%   To match FSL's ramdomise default setting, use 26 instead
+%   
+%__________________________________________________________________________
+% 
+% The maximal statistic technique is combined
+% with the threshold free cluster enhancement (TFCE) transformation due to
+% Smith & Nichols (2009), which obviates the need for arbitrary voxelwise
+% cluster-forming thresholds and instead produces continuous correct
+% p-values for all voxels. Although some spatial specifity is lost
+% relative to purely voxelwise approach, this approach, like cluster
+% corrections, is substantially less conservative due to the fact that
+% it capitalizes on spatial dependency in the data. 
+%
+% This function is taken from Mark Thornton's MatlabTFCE toolbox
+% see https://github.com/markallenthornton/MatlabTFCE
+%
+%_______________________________________________________________________
+%
+% Kyoung whan Choe (kywch@uchicago.edu)
+
+% set cluster thresholds
+threshs = 0:dh:max(img(:));
+threshs = threshs(2:end);
+ndh = length(threshs);
+
+% find positive voxels (greater than first threshold)
+nvox = length(img(:));
+
+% find connected components
+vals = zeros(nvox,1);
+cc = arrayfun(@(x) bwconncomp(bsxfun(@ge,img,x),C), threshs);
+for h = 1:ndh
+    clustsize = zeros(nvox,1);
+    ccc = cc(h);
+    voxpercc = cellfun(@numel,ccc.PixelIdxList);
+    for c = 1:ccc.NumObjects
+        clustsize(ccc.PixelIdxList{c}) = voxpercc(c);
+    end
+    % calculate transform
+    curvals = (clustsize.^E).*(threshs(h)^H);
+    vals = vals + curvals;
+end
+tfced = NaN(size(img));
+tfced(:) = vals.*dh;
+
+end
+

--- a/snpm_ui.m
+++ b/snpm_ui.m
@@ -118,6 +118,7 @@ function snpm_ui(varargin)
 % sVarSm        Sring describing variance Smoothing (empty if bVarSm=0)
 % bVolm         Flag for volumetric computation (whole volume at once)
 % bST           Flag for collection of superthreshold info 
+% bTFCE         Flag for calculating threshold-free cluster score
 % sDesFile      Name of PlugIn design file
 % sDesign       Description of PlugIn design
 % V             Memory mapping handles
@@ -278,6 +279,7 @@ G=[];Gnames='';	% Covariates (no interest)
 Gc=[];		% Covariates (no interest)	| Required only for covariate
 Gcnames=[];	% Names of covariates		| by factor interactions
 bST=0;		% Flag for collection of superthreshold info
+bTFCE=0;	% Flag for calculating threshold-free cluster score
 bVarSm=0;	% Flag for variance smoothing
 vFWHM=[0,0,0];	% FWHM for variance smoothing
 sVarSm='';	% String describing Variance Smoothing
@@ -330,7 +332,10 @@ end
 
 %-Ask about collecting Supra-Threshold cluster statistics
 %-----------------------------------------------------------------------
-bST = ~isfield(job.ST,'ST_none');
+% if 'ST_none' or 'ST_tfce' is chosen, bST = 0 & pU_ST_Ut = NaN 
+% if 'ST_later' is chosen, bST = 1 & pU_ST_Ut = -1
+% if 'ST_now' is chosen, bST = 1 & pU_ST_Ut = job.ST.ST_U;
+bST = ~or(isfield(job.ST,'ST_none'), isfield(job.ST,'ST_tfce'));
 
 % Add: get primary threshold for STC analysis if requested
 if bST
@@ -349,6 +354,14 @@ if bST
 else
   pU_ST_Ut=NaN; 
 end  
+
+%-Ask whether to apply threshold-free cluster enhancement
+bTFCE = isfield(job.ST,'ST_tfce');
+if bTFCE
+    param_TFCE = job.ST.ST_tfce;
+else
+    param_TFCE = NaN;
+end
 
 
 %-Global normalization options
@@ -584,7 +597,7 @@ CONT  = [CONT, zeros(size(CONT,1),size([B G],2))];
 s_SnPMcfg_save = ['s_SnPMcfg_save H C B G HCBGnames P PiCond ',...
 	'sPiCond bhPerms sHCform iGloNorm sGloNorm GM rg GX GMscale CONT ',...
 	'THRESH MASK ImMASK TH bVarSm vFWHM sVarSm bVolm bST sDesFile sDesign ',...
-        'V pU_ST_Ut df1 ', ...
+        'V pU_ST_Ut df1 bTFCE param_TFCE ', ...
 	'sDesSave ',sDesSave];
 eval(['save SnPMcfg ',s_SnPMcfg_save])
 


### PR DESCRIPTION
Happy New Year! and thank you for the great toolbox. 

I am using SnPM in my data analyses, so I added Threshold-free Cluster Enhancement functionality. I hope that this addition is useful for other researchers as well. Thank you!

Best regards,
Kyoung whan Choe

------------------------

Please attach '?w=1' or '&w=1' flag at the above url to ignore white spaces below during the code review.

* snpm_tfce.m - TFCE transformation function taken from Mark Thornton's MatlabTFCE toolbox (https://github.com/markallenthornton/MatlabTFCE).
* snpm_defaults.m - Default TFCE parameters -- height exponent, extent exponent, connectivity, step size -- were provided.
* snpm_ui.m - A flag for TFCE was added (bTFCE) beneath bST.
* snpm_cp.m - TFCE calculation was added. The maximal statistics are stored in MaxCSS.
* snpm_pp.m - TFCE results can be viewed from batch processing or command line.
* config/snpm_bch_ui.m - TFCE cluster inference (ST_tfce) can be selected under the 'Cluster inference' menu (ST).
* config/snpm_bch_pp.m - For TFCE inference, ClusTFCE and its FWE parameter (FWEthCSS) were added.